### PR TITLE
Add Windows code signing and fix CI versioning

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,6 +72,21 @@ jobs:
       - uses: actions/setup-dotnet@v4
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
+      - name: Stamp version in SharedAssemblyInfo.cs
+        shell: pwsh
+        run: |
+          $ver = "${{ needs.version.outputs.semver }}"
+          if ($ver -match '^(\d+)\.(\d+)\.(\d+)(?:-([a-z]+)\.?(\d+))?$') {
+            $rev = if ($Matches[4]) { $Matches[5] } else { "0" }
+            $asmVer = "$($Matches[1]).$($Matches[2]).$($Matches[3]).$rev"
+          } else { $asmVer = "$ver.0" }
+          $file = "SharedAssemblyInfo.cs"
+          (Get-Content $file -Raw) `
+            -replace 'AssemblyVersion\("[^"]*"\)', "AssemblyVersion(`"$asmVer`")" `
+            -replace 'AssemblyFileVersion\("[^"]*"\)', "AssemblyFileVersion(`"$asmVer`")" `
+            -replace 'AssemblyInformationalVersion\("[^"]*"\)', "AssemblyInformationalVersion(`"$ver`")" |
+            Set-Content $file -NoNewline
+          Write-Host "Stamped: AssemblyVersion=$asmVer, InformationalVersion=$ver"
       - name: Publish
         run: |
           dotnet publish ${{ env.MAIN_PROJECT }} `
@@ -102,6 +117,19 @@ jobs:
       - uses: actions/setup-dotnet@v4
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
+      - name: Stamp version in SharedAssemblyInfo.cs
+        run: |
+          ver="${{ needs.version.outputs.semver }}"
+          if [[ "$ver" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)(-([a-z]+)\.?([0-9]+))?$ ]]; then
+            rev="${BASH_REMATCH[6]:-0}"
+            asmVer="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}.${BASH_REMATCH[3]}.$rev"
+          else
+            asmVer="${ver}.0"
+          fi
+          sed -i "s/AssemblyVersion(\"[^\"]*\")/AssemblyVersion(\"$asmVer\")/" SharedAssemblyInfo.cs
+          sed -i "s/AssemblyFileVersion(\"[^\"]*\")/AssemblyFileVersion(\"$asmVer\")/" SharedAssemblyInfo.cs
+          sed -i "s/AssemblyInformationalVersion(\"[^\"]*\")/AssemblyInformationalVersion(\"$ver\")/" SharedAssemblyInfo.cs
+          echo "Stamped: AssemblyVersion=$asmVer, InformationalVersion=$ver"
       - name: Publish
         run: |
           dotnet publish ${{ env.MAIN_PROJECT }} \
@@ -132,6 +160,19 @@ jobs:
       - uses: actions/setup-dotnet@v4
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
+      - name: Stamp version in SharedAssemblyInfo.cs
+        run: |
+          ver="${{ needs.version.outputs.semver }}"
+          if [[ "$ver" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)(-([a-z]+)\.?([0-9]+))?$ ]]; then
+            rev="${BASH_REMATCH[6]:-0}"
+            asmVer="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}.${BASH_REMATCH[3]}.$rev"
+          else
+            asmVer="${ver}.0"
+          fi
+          sed -i '' "s/AssemblyVersion(\"[^\"]*\")/AssemblyVersion(\"$asmVer\")/" SharedAssemblyInfo.cs
+          sed -i '' "s/AssemblyFileVersion(\"[^\"]*\")/AssemblyFileVersion(\"$asmVer\")/" SharedAssemblyInfo.cs
+          sed -i '' "s/AssemblyInformationalVersion(\"[^\"]*\")/AssemblyInformationalVersion(\"$ver\")/" SharedAssemblyInfo.cs
+          echo "Stamped: AssemblyVersion=$asmVer, InformationalVersion=$ver"
       - name: Publish
         run: |
           dotnet publish ${{ env.MAIN_PROJECT }} \

--- a/.gitignore
+++ b/.gitignore
@@ -249,3 +249,4 @@ scripts/.tools/
 docs/
 *.md
 !README.md
+!CHANGELOG.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,120 @@
+# Changelog
+
+All notable changes to EveLens will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- Velopack auto-update system with delta updates across Windows, Linux, and macOS
+- GitHub Actions CI/CD pipeline — automated builds, tests, and releases on push
+- GitVersion for automatic semantic versioning from git branch topology
+- Channel-based update intervals: alpha (1h), beta (3h), stable (6h)
+- Release notes displayed in the update dialog (from GitHub Release body)
+- Force "Check for Updates" in Help menu with download + restart flow
+- **Windows code signing** with Certum Open Source Developer certificate — eliminates SmartScreen/Trojan false positives
+- `sign-release.ps1` — local script to build, sign, and upload Windows release artifacts
+- Assembly version stamping in CI for all platforms (SharedAssemblyInfo.cs updated before build)
+
+### Changed
+
+- Update system completely replaced — Velopack replaces custom AutoUpdateService, Inno Setup, AppImage scripts, and macOS bundle scripts
+- CI/CD completely replaced — GitHub Actions replaces promote.ps1 and release-*.ps1 scripts
+- Git security lock removed — GitHub branch protection rules enforce protected branches
+- GitVersion config updated for v6.x — ContinuousDelivery mode with per-branch labels
+
+### Removed
+
+- `AutoUpdateService.cs` — replaced by Velopack
+- `UpdateNotifyWindow` and `DataUpdateNotifyWindow` — replaced by inline update dialog
+- `release-alpha.ps1`, `release-beta.ps1`, `release-stable.ps1` — replaced by GitHub Actions
+- `build-installer.ps1`, `build-appimage.sh`, `build-macapp.sh` — replaced by Velopack packaging
+- `git-lock.sh`, `git-unlock.sh` — replaced by GitHub branch protection
+- `evelens-patch-*.xml` update feeds — replaced by GitHub Releases API
+
+## [1.0.0-beta.2] - 2026-03-19
+
+### Added
+
+- **ESI Health State Machine** — per-(character, endpoint) state machine replaces event-based error notifications. States: Healthy, Degraded, Failing, Suspended. Fires only on transitions — no more error spam. (Issue #34)
+- **EndpointHealthTracker** with dynamic rolling time window that self-tunes from ESI cache headers (fast endpoints = short window, slow endpoints = long window)
+- **Hysteresis recovery** — 3 consecutive successes required to transition back to Healthy, preventing the error flapping that caused ~100 activity log entries
+- **`ISchedulerStatus.GetNextFetchTime()`** — reads directly from the scheduler's priority queue, fixing the "19 hours until next refresh" stale display bug
+- **HealthNotificationSubscriber** — bridges state transitions to activity log: Failing = one entry, Suspended = one entry, recovery = auto-clear, Degraded = silence
+- **Traffic-light health dots** on character overview: green (healthy), yellow (degraded/fetching), red (failing/suspended)
+- **42 new tests** for EndpointHealthTracker covering all transitions, hysteresis, dynamic windows, edge cases
+- **In-app Diagnostic Stream viewer** — Debug menu opens a live log window with filters (All/ESI/Events/Warnings/Health/Scheduler), auto-scroll, 2000-line buffer
+- **Debug build isolation** — debug builds use `%APPDATA%\EveLens Debug\` to prevent cross-contamination with production data
+- **`update-sde.ps1`** — automated SDE update pipeline: download, extract, YamlToSqlite, XmlGenerator, diff report, version stamp
+- **Branching policy** in CLAUDE.md — all work on feature/fix/experimental branches from alpha
+
+### Changed
+
+- **SDE updated to CCP build 3261822** (Catalyst expansion, March 18 2026):
+  - 5 new skills: Capital Disintegrator Specialization, Amarr/Caldari/Gallente/Minmatar Fighter Specialization
+  - 82 new types, 31 modified types, 127 typeDogma changes
+  - All balance changes: carrier cargo bays, fighter stats (squadron 9→6, HP/DPS +50%), FAX cap booster bonuses, Black Ops tank nerfs, SOCT damage nerfs, recon targeting range -15%
+- Status bar countdown reads from scheduler queue instead of stale QueryMonitor reconstruction
+- CharacterOverviewView uses CharacterHealthSummary instead of QueryMonitors.HasErrors
+- TcpJsonLoggerProvider refactored with Start/Stop control and OnLogLine callback for in-process subscribers
+- Scheduler-driven ESI endpoints disconnected from ShouldNotifyError (8 non-scheduler callers kept for backward compat)
+
+### Fixed
+
+- ~100 ESI error entries accumulating in activity log during intermittent connectivity (Issue #34)
+- "19 hours until next refresh" stale display when error cache expires before scheduler's next fetch
+- Error notification flapping caused by ShouldNotifyError gate resetting on every success
+- XmlGenerator NuGet version conflict (System.Configuration.ConfigurationManager 8.0.0 → 8.0.1)
+- promote.ps1 version counter resetting on cross-channel promotions (array-join bug in PowerShell)
+- promote.ps1 not fetching remote ref before reading target branch version
+
+## [1.0.0-beta.1] - 2026-03-16
+
+### Added
+
+- Window position save/restore across restarts and multi-monitor setups
+
+### Fixed
+
+- promote.ps1 cross-branch merge strategy for alpha-to-beta promotions
+
+## [1.0.0-alpha.44] - 2026-03-15
+
+### Added
+
+- Smarter ESI error notifications: 3-consecutive-failure suppression for transient errors
+- Immediate notification for auth failures (401/403) and not-found (404)
+- Error categorization labels: Token refresh, Connection error, Auth expired, Not found, Rate limited, ESI server error
+- 29 new tests in ErrorNotificationTests.cs
+
+## [1.0.0-alpha.1] - 2026-02-25
+
+### Added
+
+- Cross-platform support: Windows x64, Linux x64, macOS Apple Silicon
+- Avalonia UI replacing WinForms — dark theme, modern controls
+- ESI Scheduler with priority queue, per-character rate limiting, phased cold start
+- Resilience pipeline: CircuitBreakerPolicy, CharacterAlivePolicy, RetryPolicy
+- EventAggregator replacing all static events
+- 19 character sub-tab views (Skills, Assets, Mail, Contracts, etc.)
+- MVVM ViewModels for all list views with filter/sort/group pipeline
+- Plan editor with skill browser and attribute optimizer
+- Settings migration from EVEMon (`%APPDATA%\EVEMon` → `%APPDATA%\EveLens`)
+- Auto-update checking via patch XML feeds
+- TCP diagnostic stream on port 5555 for structured JSON-lines debugging
+- 1741 tests covering architecture, models, services, serialization, integration
+
+### Changed
+
+- Complete architectural rewrite from monolithic EVEMon to modular EveLens
+- Assembly hierarchy: Core → Data → Serialization → Models → Infrastructure → Common → EveLens
+- Brand identity: EVEMon → EveLens (Character Intelligence for EVE Online)
+
+[unreleased]: https://github.com/aliacollins/evelens/compare/v1.0.0-beta.2...HEAD
+[1.0.0-beta.2]: https://github.com/aliacollins/evelens/compare/v1.0.0-beta.1...v1.0.0-beta.2
+[1.0.0-beta.1]: https://github.com/aliacollins/evelens/compare/v1.0.0-alpha.44...v1.0.0-beta.1
+[1.0.0-alpha.44]: https://github.com/aliacollins/evelens/compare/v1.0.0-alpha.1...v1.0.0-alpha.44
+[1.0.0-alpha.1]: https://github.com/aliacollins/evelens/releases/tag/v1.0.0-alpha.1

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,4 +1,4 @@
-mode: ContinuousDeployment
+mode: ContinuousDelivery
 next-version: 1.0.0
 
 branches:
@@ -6,16 +6,20 @@ branches:
     regex: ^main$
     label: ''
     increment: Patch
+    mode: ContinuousDeployment
+    is-main-branch: true
 
   alpha:
     regex: ^alpha$
     label: alpha
     increment: Minor
+    mode: ContinuousDelivery
 
   beta:
     regex: ^beta$
     label: beta
     increment: Patch
+    mode: ContinuousDelivery
 
   feature:
     regex: ^feature[/-]

--- a/README.md
+++ b/README.md
@@ -10,15 +10,11 @@
 
 ---
 
-## EveLens Is Now in Beta
+## Alpha — Experimental Testing Branch
 
-**Starting March 16, 2026** — EveLens enters beta testing ahead of its **stable release on March 20th**.
+**This is the alpha channel.** It contains the latest features and changes, but may be unstable. Use this branch to test new functionality and report issues. Things will break — that's the point.
 
 EveLens is a complete, ground-up rewrite of EVEMon — the character planner EVE pilots relied on for nearly 20 years. What was once a Windows-only desktop app locked to legacy frameworks is now a modern, cross-platform tool built on .NET 8 and Avalonia UI, running natively on **Windows, Linux, and macOS**.
-
-This isn't a patch or a fork update. It's 114,000 lines of WinForms reduced to 34,000 lines of modern code, with 1,741 tests, 14 architectural laws, and support for **100+ characters** out of the box.
-
-**Current Version: 1.0.0-beta.2**
 
 **Website:** [evelens.dev](https://evelens.dev)
 
@@ -26,28 +22,22 @@ This isn't a patch or a fork update. It's 114,000 lines of WinForms reduced to 3
 
 ## Download
 
-[EveLens Installer](https://github.com/aliacollins/evelens/releases/tag/beta)
+[Latest Alpha Release](https://github.com/aliacollins/evelens/releases)
 
 | Platform | Format | Requirements |
 |----------|--------|-------------|
-| **Windows (Installer)** | `.exe` installer | Installs .NET 8 automatically |
+| **Windows (Installer)** | `.exe` installer (code-signed) | Installs .NET 8 automatically |
 | **Windows (Portable)** | `.zip` | [.NET 8.0 Runtime](https://dotnet.microsoft.com/download/dotnet/8.0) |
-| **Linux (AppImage)** | `.AppImage` | None — just download and run |
-| **Linux (Portable)** | `.zip` | [.NET 8.0 Runtime](https://dotnet.microsoft.com/download/dotnet/8.0) |
-| **macOS (App)** | `.app.zip` | None — extract, drag to Applications |
-| **macOS (Portable)** | `.zip` | [.NET 8.0 Runtime](https://dotnet.microsoft.com/download/dotnet/8.0) |
+| **Linux** | `.zip` | [.NET 8.0 Runtime](https://dotnet.microsoft.com/download/dotnet/8.0) |
+| **macOS** | `.zip` | [.NET 8.0 Runtime](https://dotnet.microsoft.com/download/dotnet/8.0) |
 
 ### Quick Start
 
-**Windows:** Download and run the installer — it handles everything.
+**Windows:** Download and run the installer — it's code-signed, so no SmartScreen warnings.
 
-**Linux:**
-```bash
-chmod +x EveLens-1.0.0-beta.2-linux-x64.AppImage
-./EveLens-1.0.0-beta.2-linux-x64.AppImage
-```
+**Linux:** Extract and run.
 
-**macOS:** Extract the zip, drag EveLens to Applications, right-click → Open on first launch (unsigned app).
+**macOS:** Extract, drag to Applications, right-click → Open on first launch (unsigned app).
 
 > **Coming from EVEMon?** We recommend a fresh install. EveLens is a complete rewrite and a clean start gives the smoothest experience. Your EVE characters are tied to your ESI tokens, not your old settings.
 
@@ -119,29 +109,13 @@ EveLens 1.0.0 is a complete rewrite. Here's what changed from the original EVEMo
 
 ---
 
-## Alpha Changelog (Cumulative)
-
-See "What's New in 1.0.0" above for the full feature list.
-
----
-
-## Features Being Tested
-
-- Cross-platform stability on Linux and macOS
-- 100+ character ESI scheduling and resilience
-- Auto-update on all platforms
-- Group collapse/expand on overview
-- Window position/size persistence
-
----
-
 ## Update Channels
 
-| Channel | Use Case | Download |
-|---------|----------|----------|
-| Stable | Recommended for daily use (March 20th) | [Latest Release](https://github.com/aliacollins/evelens/releases/latest) |
-| **Beta** | Pre-release testing(you are here) | [Beta Release](https://github.com/aliacollins/evelens/releases/tag/beta) |
-| Alpha | Bleeding edge, experimental features | [Alpha Release](https://github.com/aliacollins/evelens/releases/tag/alpha) |
+| Channel | Use Case | Status |
+|---------|----------|--------|
+| **Alpha** | Experimental — testing new features (you are here) | Active |
+| Beta | Pre-release — feature-complete, stability testing | Coming soon |
+| Stable | Recommended for daily use | Coming soon |
 
 ---
 

--- a/scripts/sign-release.ps1
+++ b/scripts/sign-release.ps1
@@ -1,0 +1,261 @@
+<#
+.SYNOPSIS
+    Builds, signs, and uploads Windows release artifacts for EveLens.
+
+.DESCRIPTION
+    This script replaces (or creates) signed Windows artifacts in a GitHub Release.
+    CI handles Linux/macOS builds. This script handles Windows signing locally
+    because the Certum SimplySign certificate lives on this machine.
+
+.PARAMETER Version
+    SemVer version string (e.g., "1.0.0-alpha.43"). Auto-detected from GitVersion if omitted.
+
+.PARAMETER Channel
+    Release channel: alpha, beta, or stable. Auto-detected from branch if omitted.
+
+.PARAMETER SkipBuild
+    Skip the dotnet publish step (use existing publish output).
+
+.PARAMETER DryRun
+    Build and sign but don't upload to GitHub.
+
+.EXAMPLE
+    .\scripts\sign-release.ps1
+    .\scripts\sign-release.ps1 -Version "1.0.0-beta.2" -Channel beta
+    .\scripts\sign-release.ps1 -DryRun
+#>
+
+param(
+    [string]$Version,
+    [string]$Channel,
+    [switch]$SkipBuild,
+    [switch]$DryRun
+)
+
+$ErrorActionPreference = 'Stop'
+$ProjectRoot = Split-Path -Parent $PSScriptRoot
+Push-Location $ProjectRoot
+
+# ── Configuration ──
+$SignToolPath = "C:\Program Files (x86)\Windows Kits\10\bin\10.0.26100.0\x64\signtool.exe"
+$CertThumbprint = "790D3430F3154FC6ACE68E0F5701D165BFFD3BC9"
+$TimestampUrl = "http://time.certum.pl"
+$MainProject = "src/EveLens.Avalonia/EveLens.Avalonia.csproj"
+$AppName = "EveLens"
+$PublishDir = "publish/win-x64"
+$ReleaseDir = "releases/win"
+
+# ── Preflight checks ──
+Write-Host "`n=== Preflight Checks ===" -ForegroundColor Cyan
+
+# Check SimplySign cert is available
+$cert = Get-ChildItem Cert:\CurrentUser\My | Where-Object { $_.Thumbprint -eq $CertThumbprint }
+if (-not $cert) {
+    Write-Error "Certificate not found in store. Is SimplySign Desktop running and logged in?"
+    exit 1
+}
+Write-Host "  [OK] Certificate: $($cert.Subject)" -ForegroundColor Green
+
+# Check signtool
+if (-not (Test-Path $SignToolPath)) {
+    Write-Error "signtool.exe not found at: $SignToolPath"
+    exit 1
+}
+Write-Host "  [OK] signtool.exe found" -ForegroundColor Green
+
+# Check vpk
+$vpkPath = "$env:USERPROFILE\.dotnet\tools\vpk.exe"
+if (-not (Test-Path $vpkPath)) {
+    $vpkPath = (Get-Command vpk -ErrorAction SilentlyContinue).Source
+    if (-not $vpkPath) {
+        Write-Host "  [..] Installing vpk..." -ForegroundColor Yellow
+        dotnet tool install -g vpk
+        $vpkPath = "$env:USERPROFILE\.dotnet\tools\vpk.exe"
+    }
+}
+Write-Host "  [OK] vpk found" -ForegroundColor Green
+
+# Check gh
+if (-not (Get-Command gh -ErrorAction SilentlyContinue)) {
+    Write-Error "GitHub CLI (gh) not found. Install from https://cli.github.com"
+    exit 1
+}
+Write-Host "  [OK] gh CLI found" -ForegroundColor Green
+
+# ── Detect channel from branch ──
+if (-not $Channel) {
+    $branch = git rev-parse --abbrev-ref HEAD
+    switch ($branch) {
+        'main'  { $Channel = 'stable' }
+        'beta'  { $Channel = 'beta' }
+        default { $Channel = 'alpha' }
+    }
+}
+Write-Host "  [OK] Channel: $Channel" -ForegroundColor Green
+
+# ── Detect version from GitVersion ──
+if (-not $Version) {
+    Write-Host "  [..] Running GitVersion..." -ForegroundColor Yellow
+    try {
+        $gvOutput = dotnet-gitversion 2>$null | ConvertFrom-Json
+        $Version = $gvOutput.FullSemVer
+    }
+    catch {
+        # Fallback: try gitversion as dotnet tool
+        try {
+            $gvOutput = dotnet gitversion 2>$null | ConvertFrom-Json
+            $Version = $gvOutput.FullSemVer
+        }
+        catch {
+            Write-Error "Could not detect version. Install GitVersion or pass -Version explicitly."
+            exit 1
+        }
+    }
+}
+Write-Host "  [OK] Version: $Version" -ForegroundColor Green
+
+$releaseTag = "v$Version"
+Write-Host "`n  Signing: $AppName $Version ($Channel)" -ForegroundColor Magenta
+
+# ── Step 0: Update SharedAssemblyInfo.cs ──
+$SharedAssemblyInfoPath = Join-Path $ProjectRoot "SharedAssemblyInfo.cs"
+$originalContent = Get-Content $SharedAssemblyInfoPath -Raw
+
+# Parse semver: "1.0.0-alpha.1" → Major=1, Minor=0, Patch=0, PreLabel=alpha, PreNum=1
+if ($Version -match '^(\d+)\.(\d+)\.(\d+)(?:-([a-z]+)\.?(\d+))?$') {
+    $major = $Matches[1]
+    $minor = $Matches[2]
+    $patch = $Matches[3]
+    $preLabel = $Matches[4]
+    $preNum = if ($Matches[5]) { $Matches[5] } else { "0" }
+
+    # 4th component: 0 for stable, N for prerelease
+    $revision = if ($preLabel) { $preNum } else { "0" }
+    $assemblyVer = "$major.$minor.$patch.$revision"
+    $infoVer = $Version
+}
+else {
+    Write-Error "Could not parse version: $Version"
+    exit 1
+}
+
+Write-Host "`n=== Updating SharedAssemblyInfo.cs ===" -ForegroundColor Cyan
+Write-Host "  AssemblyVersion:              $assemblyVer" -ForegroundColor Green
+Write-Host "  AssemblyFileVersion:          $assemblyVer" -ForegroundColor Green
+Write-Host "  AssemblyInformationalVersion: $infoVer" -ForegroundColor Green
+
+$updatedContent = $originalContent `
+    -replace 'AssemblyVersion\("[^"]*"\)', "AssemblyVersion(`"$assemblyVer`")" `
+    -replace 'AssemblyFileVersion\("[^"]*"\)', "AssemblyFileVersion(`"$assemblyVer`")" `
+    -replace 'AssemblyInformationalVersion\("[^"]*"\)', "AssemblyInformationalVersion(`"$infoVer`")"
+
+Set-Content $SharedAssemblyInfoPath $updatedContent -NoNewline
+
+# ── Step 1: Build ──
+if (-not $SkipBuild) {
+    Write-Host "`n=== Building Windows Release ===" -ForegroundColor Cyan
+
+    if (Test-Path $PublishDir) {
+        Remove-Item $PublishDir -Recurse -Force
+    }
+
+    try {
+        dotnet publish $MainProject `
+            -c Release -r win-x64 --self-contained `
+            -o $PublishDir `
+            -p:Version=$Version
+
+        if ($LASTEXITCODE -ne 0) {
+            throw "Build failed."
+        }
+        Write-Host "  Build complete." -ForegroundColor Green
+    }
+    finally {
+        # Restore SharedAssemblyInfo.cs so we don't leave dirty working tree
+        Set-Content $SharedAssemblyInfoPath $originalContent -NoNewline
+        Write-Host "  SharedAssemblyInfo.cs restored." -ForegroundColor Gray
+    }
+}
+else {
+    # Restore immediately — no build needed
+    Set-Content $SharedAssemblyInfoPath $originalContent -NoNewline
+    if (-not (Test-Path "$PublishDir/EveLens.exe")) {
+        Write-Error "No publish output found at $PublishDir. Run without -SkipBuild."
+        exit 1
+    }
+    Write-Host "`n=== Skipping build (using existing output) ===" -ForegroundColor Yellow
+}
+
+# ── Step 2: Pack with signing ──
+Write-Host "`n=== Packing with Code Signing ===" -ForegroundColor Cyan
+
+if (Test-Path $ReleaseDir) {
+    Remove-Item $ReleaseDir -Recurse -Force
+}
+
+$signParams = "/sha1 $CertThumbprint /fd SHA256 /tr $TimestampUrl /td SHA256"
+
+& $vpkPath pack `
+    -u $AppName `
+    -v $Version `
+    -p $PublishDir `
+    -e EveLens.exe `
+    --channel $Channel `
+    --signParams $signParams `
+    -o $ReleaseDir
+
+if ($LASTEXITCODE -ne 0) {
+    Write-Error "vpk pack failed."
+    exit 1
+}
+Write-Host "  Pack complete." -ForegroundColor Green
+
+# ── Step 3: Verify signature ──
+Write-Host "`n=== Verifying Signature ===" -ForegroundColor Cyan
+
+$setupExe = Get-ChildItem "$ReleaseDir/*.exe" -ErrorAction SilentlyContinue | Select-Object -First 1
+if ($setupExe) {
+    & $SignToolPath verify /pa $setupExe.FullName
+    if ($LASTEXITCODE -eq 0) {
+        Write-Host "  Signature valid: $($setupExe.Name)" -ForegroundColor Green
+    }
+    else {
+        Write-Warning "Signature verification failed for $($setupExe.Name)"
+    }
+}
+
+# ── Step 4: Upload to GitHub Release ──
+if ($DryRun) {
+    Write-Host "`n=== DRY RUN - Skipping upload ===" -ForegroundColor Yellow
+    Write-Host "  Would upload to release: $releaseTag"
+    Get-ChildItem $ReleaseDir | ForEach-Object { Write-Host "    $($_.Name) ($([math]::Round($_.Length / 1MB, 1)) MB)" }
+}
+else {
+    Write-Host "`n=== Uploading to GitHub Release ===" -ForegroundColor Cyan
+
+    # Check if release exists
+    $releaseExists = gh release view $releaseTag --json tagName 2>$null
+    if (-not $releaseExists) {
+        Write-Host "  Creating release: $releaseTag" -ForegroundColor Yellow
+        $prerelease = if ($Channel -eq 'stable') { "" } else { "--prerelease" }
+        $title = "$AppName $Version"
+
+        gh release create $releaseTag `
+            --title $title `
+            $prerelease `
+            --notes "Signed Windows release for $Version"
+    }
+
+    # Upload artifacts (--clobber replaces existing files with same name)
+    $artifacts = Get-ChildItem $ReleaseDir
+    foreach ($artifact in $artifacts) {
+        $sizeMB = [math]::Round($artifact.Length / 1MB, 1)
+        Write-Host "  Uploading: $($artifact.Name) ($sizeMB MB)" -ForegroundColor Yellow
+        gh release upload $releaseTag $artifact.FullName --clobber
+    }
+
+    Write-Host "`n  Done! Signed release uploaded to: $releaseTag" -ForegroundColor Green
+    Write-Host "  https://github.com/aliacollins/EveLens/releases/tag/$releaseTag" -ForegroundColor Gray
+}
+
+Pop-Location


### PR DESCRIPTION
## Summary
- Windows code signing with Certum Open Source Developer certificate
- sign-release.ps1 for local signed Windows builds
- CI version stamping (SharedAssemblyInfo.cs) for all platforms
- GitVersion 6.x fix for correct pre-release labels
- CHANGELOG.md now tracked
- README updated for alpha channel

## Verified locally
- 43 files signed with Certum cert via vpk pack
- Signature chain valid through Certum Trusted Network CA
- GitVersion: alpha=1.0.0-alpha.1, beta=1.0.0-beta.1, main=1.0.0