### PR TITLE
1.3.0 features: PI overhaul, attribute fix, activity log, drag-reorder, overview cards

### DIFF
--- a/SharedAssemblyInfo.cs
+++ b/SharedAssemblyInfo.cs
@@ -30,9 +30,9 @@ using System.Runtime.InteropServices;
 //      Build Number
 //      Revision (0 for stable, 1+ for beta)
 //
-[assembly: AssemblyVersion("1.3.0.1")]
-[assembly: AssemblyFileVersion("1.3.0.1")]
-[assembly: AssemblyInformationalVersion("1.3.0-alpha.1")]
+[assembly: AssemblyVersion("1.4.0.1")]
+[assembly: AssemblyFileVersion("1.4.0.1")]
+[assembly: AssemblyInformationalVersion("1.4.0-alpha.1")]
 
 // Neutral Language
 [assembly: NeutralResourcesLanguage("en-US")]

--- a/scripts/promote.ps1
+++ b/scripts/promote.ps1
@@ -460,6 +460,38 @@ function Invoke-GitPush {
     Write-Success "Pushed to origin/$Branch"
 }
 
+function Invoke-PullRequestMerge {
+    param(
+        [string]$PromoteBranch,
+        [string]$TargetBranch,
+        [string]$Title,
+        [string]$Body
+    )
+
+    if (-not $DryRun) {
+        # Push the promote branch
+        git push --no-verify origin "refs/heads/${PromoteBranch}:refs/heads/${PromoteBranch}"
+        if ($LASTEXITCODE -ne 0) { throw "git push promote branch failed (exit code $LASTEXITCODE)" }
+        Write-Success "Pushed promote branch: $PromoteBranch"
+
+        # Create PR
+        $prUrl = gh pr create --base $TargetBranch --head $PromoteBranch --title $Title --body $Body --repo aliacollins/EveLens 2>&1
+        if ($LASTEXITCODE -ne 0) { throw "PR creation failed: $prUrl" }
+        Write-Success "Created PR: $prUrl"
+
+        # Merge PR (0 approvals required, merges immediately)
+        gh pr merge $prUrl --merge --repo aliacollins/EveLens 2>&1
+        if ($LASTEXITCODE -ne 0) { throw "PR merge failed for $prUrl" }
+        Write-Success "Merged PR into $TargetBranch"
+
+        # Clean up remote promote branch
+        git push origin --delete "refs/heads/$PromoteBranch" 2>$null
+        Write-Info "Deleted remote promote branch"
+    } else {
+        Write-Info "[DRY RUN] Would push $PromoteBranch, create PR to $TargetBranch, and merge"
+    }
+}
+
 function Invoke-GitMerge {
     param(
         [string]$SourceBranch,
@@ -632,18 +664,20 @@ function Invoke-Promote {
 
     $isCrossBranch = ($currentBranch -ne $targetBranch)
 
+    # All promotions use a temporary branch + PR to satisfy branch protection.
+    # Protected branches (main, alpha, beta) require PRs — no direct push.
+    $timestamp = Get-Date -Format "yyyyMMdd-HHmmss"
+    $promoteBranch = "promote/$Channel-$timestamp"
+
     if ($isCrossBranch) {
         # ================================================================
         # CROSS-BRANCH PROMOTE (e.g., feature->alpha, alpha->beta)
-        # Merge first, then update version files on the TARGET branch.
-        # This prevents polluting the source branch with target-specific
-        # version, badge, installer link, and "you are here" changes.
+        # Merge source into a promote branch based on target, update version
+        # files, then PR into the protected target branch.
         # ================================================================
 
-        # Phase 2: Push source and merge to target
-        Write-Step "Phase 2: Merging $currentBranch -> $targetBranch..."
+        Write-Step "Phase 2: Preparing promote branch from $targetBranch..."
 
-        $pushed = $false
         try {
             # Commit any uncommitted changes on source branch first
             if (-not $DryRun) {
@@ -659,71 +693,37 @@ function Invoke-Promote {
 
             Write-Info "Pushing $currentBranch..."
             Invoke-GitPush $currentBranch
-            $pushed = $true
 
-            Write-Info "Merging $currentBranch -> $targetBranch..."
-            Invoke-GitMerge $currentBranch $targetBranch
+            if (-not $DryRun) {
+                # Create promote branch from target, merge source into it
+                git fetch origin "refs/heads/${targetBranch}:refs/remotes/origin/${targetBranch}" 2>$null
+                git checkout -B $promoteBranch "origin/$targetBranch"
+                if ($LASTEXITCODE -ne 0) { throw "git checkout promote branch from $targetBranch failed" }
+
+                # Merge source branch into promote branch
+                git merge $currentBranch --no-ff -m "Merge $currentBranch into $targetBranch"
+                if ($LASTEXITCODE -ne 0) {
+                    git merge --abort 2>$null
+                    Write-Warning "Normal merge conflicted. Retrying with source-wins strategy..."
+                    git merge $currentBranch --no-ff -X theirs -m "Merge $currentBranch into $targetBranch"
+                    if ($LASTEXITCODE -ne 0) {
+                        git merge --abort 2>$null
+                        throw "Merge conflict: $currentBranch into promote branch failed even with -X theirs. Manual resolution required."
+                    }
+                }
+                Write-Success "Merged $currentBranch into promote branch"
+            }
         } catch {
             Write-Error "Merge failed: $_"
-            if (-not $pushed -and -not $DryRun) {
-                Write-Warning "Nothing was pushed. Rolling back..."
-                git reset HEAD~1 2>$null
-                git checkout -- .
-                Write-Warning "Rollback complete."
-            } elseif (-not $DryRun) {
-                Write-Warning "Source branch was pushed but merge failed."
-                Write-Warning "Resolve manually: git checkout $targetBranch && git merge $currentBranch"
-            }
-            exit 1
-        }
-
-        # Phase 3: Update version files on the TARGET branch and commit
-        Write-Step "Phase 3: Updating version files on $targetBranch..."
-
-        try {
-            Update-SharedAssemblyInfo $nextVersion $Channel
-            Update-Changelog $nextVersion $Message $Channel
-            Update-PatchXml $nextVersion $Channel $Message
-            Update-ReadmeVersion $nextVersion $Channel
-        } catch {
-            Write-Error "File update failed on $targetBranch`: $_"
             if (-not $DryRun) {
-                Write-Warning "Rolling back file changes on $targetBranch..."
-                git checkout -- .
-                Write-Warning "Rollback complete. Merge is intact but version was not bumped."
+                git checkout $currentBranch 2>$null
+                git branch -D $promoteBranch 2>$null
             }
             exit 1
         }
 
-        try {
-            Invoke-GitCommit $commitMsg
-        } catch {
-            Write-Error "Commit failed on $targetBranch`: $_"
-            if (-not $DryRun) {
-                Write-Warning "Rolling back file changes..."
-                git checkout -- .
-            }
-            exit 1
-        }
-
-        # Push target
-        Write-Step "Pushing $targetBranch..."
-        try {
-            Invoke-GitPush $targetBranch
-        } catch {
-            Write-Error "Push to $targetBranch failed: $_"
-            Write-Warning "Commit is local. Retry with: git push origin $targetBranch"
-            exit 1
-        }
-
-    } else {
-        # ================================================================
-        # SAME-BRANCH PROMOTE (e.g., alpha->alpha when already on alpha)
-        # Update files, commit, push - all on the current branch.
-        # ================================================================
-
-        # Phase 2: Update version files
-        Write-Step "Phase 2: Updating version files..."
+        # Phase 3: Update version files on the promote branch and commit
+        Write-Step "Phase 3: Updating version files on promote branch..."
 
         try {
             Update-SharedAssemblyInfo $nextVersion $Channel
@@ -733,40 +733,99 @@ function Invoke-Promote {
         } catch {
             Write-Error "File update failed: $_"
             if (-not $DryRun) {
-                Write-Warning "Rolling back all file changes..."
-                git checkout -- .
-                Write-Warning "Rollback complete. No files were changed."
+                git checkout $currentBranch 2>$null
+                git branch -D $promoteBranch 2>$null
             }
             exit 1
         }
-
-        # Phase 3: Commit and push
-        Write-Step "Phase 3: Committing and pushing..."
 
         try {
             Invoke-GitCommit $commitMsg
         } catch {
             Write-Error "Commit failed: $_"
             if (-not $DryRun) {
-                Write-Warning "Rolling back file changes..."
+                git checkout $currentBranch 2>$null
+                git branch -D $promoteBranch 2>$null
+            }
+            exit 1
+        }
+
+        # PR into target
+        Write-Step "Phase 3b: Creating PR to $targetBranch..."
+        try {
+            Invoke-PullRequestMerge $promoteBranch $targetBranch $commitMsg "Automated promotion: $currentBranch -> $targetBranch ($nextVersion)`n`n$Message"
+        } catch {
+            Write-Error "PR merge failed: $_"
+            Write-Warning "Promote branch '$promoteBranch' is still on remote. Create PR manually."
+            if (-not $DryRun) { git checkout $currentBranch 2>$null }
+            exit 1
+        }
+
+        # Return to source branch and sync local target
+        if (-not $DryRun) {
+            git checkout $currentBranch 2>$null
+            git fetch origin "refs/heads/${targetBranch}:refs/heads/${targetBranch}" 2>$null
+            git branch -D $promoteBranch 2>$null
+        }
+
+    } else {
+        # ================================================================
+        # SAME-BRANCH PROMOTE (e.g., on alpha, promoting to alpha)
+        # Create a promote branch from current state, update version files,
+        # then PR into the protected branch.
+        # ================================================================
+
+        Write-Step "Phase 2: Preparing promote branch..."
+
+        if (-not $DryRun) {
+            git checkout -b $promoteBranch
+            if ($LASTEXITCODE -ne 0) { throw "Failed to create promote branch" }
+        }
+
+        try {
+            Update-SharedAssemblyInfo $nextVersion $Channel
+            Update-Changelog $nextVersion $Message $Channel
+            Update-PatchXml $nextVersion $Channel $Message
+            Update-ReadmeVersion $nextVersion $Channel
+        } catch {
+            Write-Error "File update failed: $_"
+            if (-not $DryRun) {
                 git checkout -- .
-                Write-Warning "Rollback complete. No commit was created."
+                git checkout $targetBranch 2>$null
+                git branch -D $promoteBranch 2>$null
+            }
+            exit 1
+        }
+
+        # Phase 3: Commit and PR
+        Write-Step "Phase 3: Committing and creating PR..."
+
+        try {
+            Invoke-GitCommit $commitMsg
+        } catch {
+            Write-Error "Commit failed: $_"
+            if (-not $DryRun) {
+                git checkout -- .
+                git checkout $targetBranch 2>$null
+                git branch -D $promoteBranch 2>$null
             }
             exit 1
         }
 
         try {
-            Write-Info "Pushing $targetBranch..."
-            Invoke-GitPush $targetBranch
+            Invoke-PullRequestMerge $promoteBranch $targetBranch $commitMsg "Automated promotion: $targetBranch ($nextVersion)`n`n$Message"
         } catch {
-            Write-Error "Push failed: $_"
-            if (-not $DryRun) {
-                Write-Warning "Rolling back local commit..."
-                git reset HEAD~1
-                git checkout -- .
-                Write-Warning "Rollback complete. No changes were pushed."
-            }
+            Write-Error "PR merge failed: $_"
+            Write-Warning "Promote branch '$promoteBranch' is still on remote. Create PR manually."
+            if (-not $DryRun) { git checkout $targetBranch 2>$null }
             exit 1
+        }
+
+        # Return to target branch and sync
+        if (-not $DryRun) {
+            git checkout $targetBranch 2>$null
+            git pull origin $targetBranch 2>$null
+            git branch -D $promoteBranch 2>$null
         }
     }
 

--- a/src/EveLens.Avalonia/Controls/ColonyFlowCanvas.cs
+++ b/src/EveLens.Avalonia/Controls/ColonyFlowCanvas.cs
@@ -1,0 +1,512 @@
+// EveLens — Character Intelligence for EVE Online
+// Copyright © 2006-2021 EVEMon Development Team, © 2025-2026 Alia Collins
+// Built with Claude Code (Anthropic)
+// Licensed under GPL v2 — see LICENSE for details
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Media;
+using Avalonia.Rendering.SceneGraph;
+using Avalonia.Skia;
+using EveLens.Common.Constants;
+using EveLens.Common.Models;
+using EveLens.Common.Services.Planetary;
+using SkiaSharp;
+
+namespace EveLens.Avalonia.Controls
+{
+    /// <summary>
+    /// Renders a colony's production chain as a left-to-right flow diagram.
+    /// Columns: Extractors → Storage → Factories → Export
+    /// Lines connect via routes, colored by material tier.
+    /// </summary>
+    public sealed class ColonyFlowCanvas : Control
+    {
+        private ColonyAnalysis? _analysis;
+        private PlanetaryColony? _colony;
+        private List<FlowNode> _nodes = new();
+        private List<FlowEdge> _edges = new();
+        private bool _needsRelayout;
+
+        public ColonyFlowCanvas()
+        {
+            HorizontalAlignment = global::Avalonia.Layout.HorizontalAlignment.Stretch;
+            VerticalAlignment = global::Avalonia.Layout.VerticalAlignment.Stretch;
+        }
+
+        protected override Size MeasureOverride(Size availableSize)
+        {
+            double w = double.IsInfinity(availableSize.Width) ? 900 : availableSize.Width;
+            int nodeCount = Math.Max(_nodes.Count(n => n.Column == 0), Math.Max(_nodes.Count(n => n.Column == 1), _nodes.Count(n => n.Column == 2)));
+            double h = Math.Max(280, 60 + nodeCount * 52);
+            return new Size(w, h);
+        }
+
+        protected override void OnSizeChanged(SizeChangedEventArgs e)
+        {
+            base.OnSizeChanged(e);
+            if (_nodes.Count > 0)
+            {
+                _needsRelayout = true;
+                InvalidateVisual();
+            }
+        }
+
+        public void SetColony(PlanetaryColony colony)
+        {
+            _colony = colony;
+            _analysis = ProductionChainAnalyzer.Analyze(colony);
+            _needsRelayout = true;
+            LayoutNodes();
+            InvalidateVisual();
+        }
+
+        public void Clear()
+        {
+            _colony = null;
+            _analysis = null;
+            _nodes.Clear();
+            _edges.Clear();
+            InvalidateVisual();
+        }
+
+        private void LayoutNodes()
+        {
+            _nodes.Clear();
+            _edges.Clear();
+
+            if (_colony == null || _analysis == null) return;
+
+            var pins = _colony.Pins.ToList();
+            var routes = _colony.Routes.ToList();
+
+            // Classify pins into columns
+            var extractors = new List<PlanetaryPin>();
+            var factories = new List<PlanetaryPin>();
+            var storage = new List<PlanetaryPin>();
+
+            var storageGroups = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+                { "Command Centers", "Spaceports", "Storage Facilities" };
+
+            foreach (var pin in pins)
+            {
+                if (DBConstants.EcuTypeIDs.Contains(pin.TypeID))
+                    extractors.Add(pin);
+                else if (pin.SchematicID > 0)
+                    factories.Add(pin);
+                else if (storageGroups.Contains(pin.GroupName ?? ""))
+                    storage.Add(pin);
+            }
+
+            // Group factories by production tier for separate columns
+            var factoryByTier = factories
+                .Select(f => (pin: f, info: _analysis.Factories.FirstOrDefault(fi => fi.Pin == f)))
+                .GroupBy(x => x.info?.Tier ?? ProductionTier.Basic)
+                .OrderBy(g => g.Key)
+                .ToList();
+
+            // Dynamic columns: ECU(0) | Storage(1) | P1 Factories(2) | P2 Factories(3) | ...
+            int numColumns = 2 + factoryByTier.Count;
+            float availableWidth = Math.Max((float)Bounds.Width, 700f);
+            float colWidth = (availableWidth - 60f) / numColumns;
+            const float nodeHeight = 44f;
+            const float nodeSpacing = 10f;
+            const float startX = 30f;
+            const float startY = 60f;
+
+            // Column 0: Extractors
+            float y = startY;
+            foreach (var pin in extractors)
+            {
+                var ext = _analysis.Extractors.FirstOrDefault(e => e.Pin == pin);
+                string label = ext != null && !string.IsNullOrEmpty(ext.OutputTypeName)
+                    ? ext.OutputTypeName
+                    : !string.IsNullOrEmpty(pin.ContentTypeName) ? pin.ContentTypeName : "Extractor";
+                string detail = ext != null && ext.CurrentYieldPerHour > 0
+                    ? $"{ext.CurrentYieldPerHour:F0}/hr"
+                    : pin.State == Common.Enumerations.PlanetaryPinState.Extracting ? "Active" : "Idle";
+                var state = pin.State == Common.Enumerations.PlanetaryPinState.Extracting
+                    ? FlowNodeState.Active : FlowNodeState.Idle;
+
+                _nodes.Add(new FlowNode(pin.ID, label, detail, "ECU", 0, startX, y, state));
+                y += nodeHeight + nodeSpacing;
+            }
+
+            // Column 1: Storage
+            y = startY;
+            foreach (var pin in storage)
+            {
+                string label = pin.TypeName;
+                string detail = pin.ContentQuantity > 0 ? $"{pin.ContentQuantity} units" : "Empty";
+                _nodes.Add(new FlowNode(pin.ID, label, detail, "Store", 1, startX + colWidth, y, FlowNodeState.Neutral));
+                y += nodeHeight + nodeSpacing;
+            }
+
+            // Columns 2+: Factories grouped by tier
+            int colIndex = 2;
+            foreach (var tierGroup in factoryByTier)
+            {
+                y = startY;
+                string tierLabel = tierGroup.Key switch
+                {
+                    ProductionTier.Basic => "P1",
+                    ProductionTier.Advanced => "P2",
+                    ProductionTier.AdvancedP3 => "P3",
+                    ProductionTier.HighTech => "P4",
+                    _ => "Fac"
+                };
+
+                foreach (var (pin, info) in tierGroup)
+                {
+                    string label = info?.OutputName ?? pin.TypeName;
+                    string detail = info != null ? $"{info.OutputPerHour}/hr" : "";
+                    _nodes.Add(new FlowNode(pin.ID, label, detail, tierLabel, colIndex, startX + colWidth * colIndex, y, FlowNodeState.Active));
+                    y += nodeHeight + nodeSpacing;
+                }
+                colIndex++;
+            }
+
+            // Build edges from routes
+            var nodeMap = _nodes.ToDictionary(n => n.PinID);
+            foreach (var route in routes)
+            {
+                if (nodeMap.TryGetValue(route.SourcePinID, out var from) &&
+                    nodeMap.TryGetValue(route.DestinationPinID, out var to))
+                {
+                    int tier = route.ContentTypeID > 0
+                        ? InferTierFromTypeId(route.ContentTypeID)
+                        : 0;
+                    _edges.Add(new FlowEdge(from, to, tier));
+                }
+            }
+        }
+
+        private static int InferTierFromTypeId(int typeId)
+        {
+            var schematic = PlanetarySchematicsProvider.GetSchematicByOutputType(typeId);
+            if (schematic == null) return 0; // P0 raw
+            return schematic.Tier switch
+            {
+                ProductionTier.Basic => 1,
+                ProductionTier.Advanced => 2,
+                ProductionTier.AdvancedP3 => 3,
+                ProductionTier.HighTech => 4,
+                _ => 0
+            };
+        }
+
+        public override void Render(DrawingContext context)
+        {
+            base.Render(context);
+
+            if (_needsRelayout && Bounds.Width > 100)
+            {
+                _needsRelayout = false;
+                RelayoutWithWidth((float)Bounds.Width);
+            }
+
+            context.Custom(new FlowDrawOp(
+                new Rect(0, 0, Bounds.Width, Bounds.Height),
+                _nodes, _edges, _colony?.PlanetName ?? ""));
+        }
+
+        private void RelayoutWithWidth(float width)
+        {
+            if (_colony != null)
+            {
+                LayoutNodes();
+                return;
+            }
+
+            // Determine how many columns are in use
+            int maxCol = 0;
+            foreach (var node in _nodes)
+                if (node.Column > maxCol) maxCol = node.Column;
+
+            int numCols = maxCol + 1;
+            float colWidth = (width - 60f) / numCols;
+            const float startX = 30f;
+
+            foreach (var node in _nodes)
+                node.X = startX + node.Column * colWidth;
+        }
+
+        private sealed class FlowDrawOp : ICustomDrawOperation
+        {
+            private readonly Rect _bounds;
+            private readonly List<FlowNode> _nodes;
+            private readonly List<FlowEdge> _edges;
+            private readonly string _title;
+
+            public FlowDrawOp(Rect bounds, List<FlowNode> nodes, List<FlowEdge> edges, string title)
+            {
+                _bounds = bounds;
+                _nodes = nodes;
+                _edges = edges;
+                _title = title;
+            }
+
+            public Rect Bounds => _bounds;
+
+            public void Dispose() { }
+
+            public bool Equals(ICustomDrawOperation? other) => false;
+
+            public bool HitTest(Point p) => _bounds.Contains(p);
+
+            public void Render(ImmediateDrawingContext context)
+            {
+                var leaseFeature = context.TryGetFeature(typeof(ISkiaSharpApiLeaseFeature));
+                if (leaseFeature is not ISkiaSharpApiLeaseFeature skiaFeature) return;
+
+                using var lease = skiaFeature.Lease();
+                var canvas = lease.SkCanvas;
+
+                canvas.Clear(new SKColor(18, 22, 30)); // dark space background
+
+                DrawColumnHeaders(canvas);
+                DrawEdges(canvas);
+                DrawNodes(canvas);
+                DrawTitle(canvas);
+            }
+
+            private void DrawTitle(SKCanvas canvas)
+            {
+                if (string.IsNullOrEmpty(_title)) return;
+                using var paint = new SKPaint
+                {
+                    Color = new SKColor(200, 170, 80),
+                    TextSize = 14,
+                    IsAntialias = true,
+                    Typeface = SKTypeface.FromFamilyName("Segoe UI", SKFontStyle.Bold)
+                };
+                canvas.DrawText(_title, 40, 30, paint);
+            }
+
+            private void DrawColumnHeaders(SKCanvas canvas)
+            {
+                using var paint = new SKPaint
+                {
+                    Color = new SKColor(120, 130, 150),
+                    TextSize = 11,
+                    IsAntialias = true
+                };
+
+                // Derive column headers from actual node data
+                var columns = _nodes.Select(n => n.Column).Distinct().OrderBy(c => c).ToList();
+                if (columns.Count == 0) return;
+
+                int maxCol = columns.Max();
+                float colWidth = ((float)_bounds.Width - 60f) / (maxCol + 1);
+
+                foreach (int col in columns)
+                {
+                    string header = _nodes.FirstOrDefault(n => n.Column == col)?.Role ?? "";
+                    header = col switch
+                    {
+                        0 => "Extractors",
+                        1 => "Storage",
+                        _ => header + " Factories"
+                    };
+                    canvas.DrawText(header, 30 + col * colWidth, 50, paint);
+                }
+            }
+
+            private void DrawEdges(SKCanvas canvas)
+            {
+                float canvasW = (float)_bounds.Width;
+                int maxCol = _nodes.Count > 0 ? _nodes.Max(n => n.Column) + 1 : 3;
+                float nodeW = Math.Min(180, (canvasW - 60f) / maxCol - 40f);
+
+                foreach (var edge in _edges)
+                {
+                    var color = GetTierColor(edge.Tier);
+                    float strokeWidth = GetTierStrokeWidth(edge.Tier);
+
+                    using var paint = new SKPaint
+                    {
+                        Color = color,
+                        StrokeWidth = strokeWidth,
+                        IsAntialias = true,
+                        Style = SKPaintStyle.Stroke
+                    };
+
+                    // Add gap: start 8px past node right edge, end 8px before dest left edge
+                    float fromX = edge.From.X + nodeW + 8;
+                    float fromY = edge.From.Y + 22;
+                    float toX = edge.To.X - 8;
+                    float toY = edge.To.Y + 22;
+
+                    using var path = new SKPath();
+                    path.MoveTo(fromX, fromY);
+
+                    float cpOffset = (toX - fromX) * 0.4f;
+                    path.CubicTo(fromX + cpOffset, fromY, toX - cpOffset, toY, toX, toY);
+                    canvas.DrawPath(path, paint);
+
+                    // Arrow head (scaled by stroke width)
+                    float arrowSize = 5 + strokeWidth;
+                    using var arrowPaint = new SKPaint
+                    {
+                        Color = color,
+                        Style = SKPaintStyle.Fill,
+                        IsAntialias = true
+                    };
+                    using var arrow = new SKPath();
+                    arrow.MoveTo(toX, toY);
+                    arrow.LineTo(toX - arrowSize, toY - arrowSize * 0.6f);
+                    arrow.LineTo(toX - arrowSize, toY + arrowSize * 0.6f);
+                    arrow.Close();
+                    canvas.DrawPath(arrow, arrowPaint);
+                }
+            }
+
+            private void DrawNodes(SKCanvas canvas)
+            {
+                foreach (var node in _nodes)
+                {
+                    DrawSingleNode(canvas, node);
+                }
+            }
+
+            private void DrawSingleNode(SKCanvas canvas, FlowNode node)
+            {
+                float canvasWidth = (float)_bounds.Width;
+                int maxCol = _nodes.Count > 0 ? _nodes.Max(n => n.Column) + 1 : 3;
+                float w = Math.Min(180, (canvasWidth - 60f) / maxCol - 40f);
+                float h = 44;
+                var rect = new SKRect(node.X, node.Y, node.X + w, node.Y + h);
+
+                // Background
+                var bgColor = node.State switch
+                {
+                    FlowNodeState.Active => new SKColor(30, 50, 40),
+                    FlowNodeState.Idle => new SKColor(50, 30, 30),
+                    _ => new SKColor(35, 38, 48)
+                };
+                using var bgPaint = new SKPaint { Color = bgColor, Style = SKPaintStyle.Fill, IsAntialias = true };
+                canvas.DrawRoundRect(rect, 6, 6, bgPaint);
+
+                // Border
+                var borderColor = node.State switch
+                {
+                    FlowNodeState.Active => new SKColor(80, 200, 120),
+                    FlowNodeState.Idle => new SKColor(200, 80, 80),
+                    _ => new SKColor(80, 90, 110)
+                };
+                using var borderPaint = new SKPaint { Color = borderColor, StrokeWidth = 1.5f, Style = SKPaintStyle.Stroke, IsAntialias = true };
+                canvas.DrawRoundRect(rect, 6, 6, borderPaint);
+
+                // Role badge (small tag)
+                using var badgePaint = new SKPaint { Color = borderColor.WithAlpha(60), Style = SKPaintStyle.Fill };
+                var badgeRect = new SKRect(node.X + 4, node.Y + 4, node.X + 44, node.Y + 16);
+                canvas.DrawRoundRect(badgeRect, 3, 3, badgePaint);
+
+                using var badgeTextPaint = new SKPaint
+                {
+                    Color = borderColor,
+                    TextSize = 9,
+                    IsAntialias = true
+                };
+                canvas.DrawText(node.Role, node.X + 8, node.Y + 14, badgeTextPaint);
+
+                // Main label
+                using var labelPaint = new SKPaint
+                {
+                    Color = SKColors.White,
+                    TextSize = 11,
+                    IsAntialias = true,
+                    Typeface = SKTypeface.FromFamilyName("Segoe UI", SKFontStyle.Bold)
+                };
+                canvas.DrawText(TruncateText(node.Label, 22), node.X + 8, node.Y + 30, labelPaint);
+
+                // Detail text (right-aligned)
+                if (!string.IsNullOrEmpty(node.Detail))
+                {
+                    using var detailPaint = new SKPaint
+                    {
+                        Color = new SKColor(150, 160, 180),
+                        TextSize = 9,
+                        IsAntialias = true,
+                        TextAlign = SKTextAlign.Right
+                    };
+                    canvas.DrawText(node.Detail, node.X + w - 8, node.Y + 40, detailPaint);
+                }
+            }
+
+            private static SKColor GetTierColor(int tier) => tier switch
+            {
+                0 => new SKColor(130, 140, 150),  // P0 - gray
+                1 => new SKColor(70, 180, 220),   // P1 - cyan/blue
+                2 => new SKColor(200, 80, 220),   // P2 - vivid purple/magenta
+                3 => new SKColor(240, 160, 40),   // P3 - bright orange
+                4 => new SKColor(240, 210, 60),   // P4 - gold
+                _ => new SKColor(100, 100, 100)
+            };
+
+            private static float GetTierStrokeWidth(int tier) => tier switch
+            {
+                0 => 1.5f,
+                1 => 2f,
+                2 => 2.5f,
+                3 => 3f,
+                4 => 3.5f,
+                _ => 1.5f
+            };
+
+            private static string TruncateText(string text, int maxLen)
+            {
+                if (text.Length <= maxLen) return text;
+                return text.Substring(0, maxLen - 1) + "...";
+            }
+        }
+    }
+
+    internal sealed class FlowNode
+    {
+        public long PinID { get; }
+        public string Label { get; }
+        public string Detail { get; }
+        public string Role { get; }
+        public int Column { get; }
+        public float X { get; set; }
+        public float Y { get; }
+        public FlowNodeState State { get; }
+
+        public FlowNode(long pinId, string label, string detail, string role, int col, float x, float y, FlowNodeState state)
+        {
+            PinID = pinId;
+            Label = label;
+            Detail = detail;
+            Role = role;
+            Column = col;
+            X = x;
+            Y = y;
+            State = state;
+        }
+    }
+
+    internal sealed class FlowEdge
+    {
+        public FlowNode From { get; }
+        public FlowNode To { get; }
+        public int Tier { get; }
+
+        public FlowEdge(FlowNode from, FlowNode to, int tier)
+        {
+            From = from;
+            To = to;
+            Tier = tier;
+        }
+    }
+
+    internal enum FlowNodeState
+    {
+        Active,
+        Idle,
+        Neutral
+    }
+}

--- a/src/EveLens.Avalonia/EveLens.Avalonia.csproj
+++ b/src/EveLens.Avalonia/EveLens.Avalonia.csproj
@@ -19,6 +19,8 @@
     <PackageReference Include="Avalonia.Themes.Fluent" Version="11.2.3" />
     <PackageReference Include="Avalonia.Controls.DataGrid" Version="11.2.3" />
     <PackageReference Include="Avalonia.Diagnostics" Version="11.2.3" Condition="'$(Configuration)' == 'Debug'" />
+    <PackageReference Include="DesktopNotifications" Version="1.3.1" />
+    <PackageReference Include="DesktopNotifications.Windows" Version="1.3.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.1" />
     <PackageReference Include="SkiaSharp" Version="2.88.9" />

--- a/src/EveLens.Avalonia/Program.cs
+++ b/src/EveLens.Avalonia/Program.cs
@@ -55,6 +55,9 @@ namespace EveLens.Avalonia
                 return;
             }
 
+            // Initialize native OS notification manager
+            NativeNotificationService.Initialize();
+
             // Force Western number formatting (XXX,XXX.XX) regardless of system locale
             CultureInfo.DefaultThreadCurrentCulture = CultureInfo.InvariantCulture;
             CultureInfo.DefaultThreadCurrentUICulture = CultureInfo.InvariantCulture;

--- a/src/EveLens.Avalonia/Program.cs
+++ b/src/EveLens.Avalonia/Program.cs
@@ -16,8 +16,6 @@ using Avalonia.Media;
 using Avalonia.Themes.Fluent;
 using EveLens.Common;
 using Velopack;
-
-using Velopack;
 using EveLens.Avalonia.Services;
 namespace EveLens.Avalonia
 {

--- a/src/EveLens.Avalonia/Services/NativeNotificationService.cs
+++ b/src/EveLens.Avalonia/Services/NativeNotificationService.cs
@@ -4,45 +4,48 @@
 // Licensed under GPL v2 — see LICENSE for details
 
 using System;
-using System.Diagnostics;
-using System.IO;
 using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+using DesktopNotifications;
+using DesktopNotifications.Windows;
 using EveLens.Common.Services;
 using Microsoft.Extensions.Logging;
 
 namespace EveLens.Avalonia.Services
 {
-    /// <summary>
-    /// Cross-platform native OS notification service.
-    ///   Windows — WinRT ToastNotification with registered AUMID (Start menu shortcut)
-    ///   Linux   — notify-send (libnotify)
-    ///   macOS   — osascript display notification
-    /// </summary>
     internal static class NativeNotificationService
     {
-        private const string AppId = "EveLens";
-        private const string AppDisplayName = "EveLens";
         private static ILogger? s_logger;
-        private static bool s_windowsInitialized;
+        private static INotificationManager? s_manager;
 
         private static ILogger Logger =>
             s_logger ??= AppServices.LoggerFactory.CreateLogger("NativeNotification");
+
+        public static void Initialize()
+        {
+            try
+            {
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                    s_manager = new WindowsNotificationManager();
+                else
+                    return;
+
+                s_manager.Initialize().GetAwaiter().GetResult();
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError(ex, "Failed to initialize notification manager");
+            }
+        }
 
         public static void Show(string title, string message)
         {
             try
             {
-                Logger.LogInformation("Show — platform={Platform}, title='{Title}'",
-                    Environment.OSVersion.Platform, title);
+                if (s_manager == null)
+                    return;
 
-                if (OperatingSystem.IsWindows())
-                    ShowWindows(title, message);
-                else if (OperatingSystem.IsLinux())
-                    ShowLinux(title, message);
-                else if (OperatingSystem.IsMacOS())
-                    ShowMacOS(title, message);
-                else
-                    Logger.LogWarning("Unsupported platform for native notifications");
+                _ = ShowAsync(title, message);
             }
             catch (Exception ex)
             {
@@ -50,225 +53,23 @@ namespace EveLens.Avalonia.Services
             }
         }
 
-        [System.Runtime.Versioning.SupportedOSPlatform("windows10.0.19041.0")]
-        private static void ShowWindows(string title, string message)
+        private static async Task ShowAsync(string title, string message)
         {
             try
             {
-                // Windows 11 requires apps to have a registered AUMID (Application User Model ID)
-                // to show toast notifications. We register by creating a Start menu shortcut
-                // with the AUMID property set — this is the same mechanism all desktop apps use.
-                if (!s_windowsInitialized)
+                var notification = new Notification
                 {
-                    EnsureWindowsShortcut();
-                    s_windowsInitialized = true;
-                }
-
-                string xmlTitle = EscapeXml(title);
-                string xmlMessage = EscapeXml(message);
-
-                string toastXml =
-                    "<toast>" +
-                        "<visual>" +
-                            "<binding template=\"ToastGeneric\">" +
-                                $"<text>{xmlTitle}</text>" +
-                                $"<text>{xmlMessage}</text>" +
-                            "</binding>" +
-                        "</visual>" +
-                    "</toast>";
-
-                // Use reflection to invoke WinRT toast APIs to avoid compile-time dependency
-                // on net8.0-windows TFM (keeping cross-platform net8.0 target).
-                var xmlDocType = Type.GetType("Windows.Data.Xml.Dom.XmlDocument, Microsoft.Windows.SDK.NET");
-                if (xmlDocType == null)
-                {
-                    Logger.LogWarning("WinRT XmlDocument type not available — falling back to silent notification");
-                    return;
-                }
-                var doc = Activator.CreateInstance(xmlDocType)!;
-                xmlDocType.GetMethod("LoadXml")!.Invoke(doc, new object[] { toastXml });
-
-                var toastNotificationType = Type.GetType("Windows.UI.Notifications.ToastNotification, Microsoft.Windows.SDK.NET")!;
-                var toast = Activator.CreateInstance(toastNotificationType, doc)!;
-
-                var managerType = Type.GetType("Windows.UI.Notifications.ToastNotificationManager, Microsoft.Windows.SDK.NET")!;
-                var notifier = managerType.GetMethod("CreateToastNotifier", new[] { typeof(string) })!
-                    .Invoke(null, new object[] { AppId })!;
-                notifier.GetType().GetMethod("Show")!.Invoke(notifier, new[] { toast });
-
-                Logger.LogInformation("Windows toast shown via WinRT API (AUMID={AppId})", AppId);
-            }
-            catch (Exception ex)
-            {
-                Logger.LogError(ex, "WinRT toast notification failed");
-            }
-        }
-
-        /// <summary>
-        /// Creates a Start menu shortcut with the AUMID property so Windows recognizes the app
-        /// as a valid toast notification source. This is the standard mechanism for desktop
-        /// (non-MSIX/non-Store) apps. The shortcut is created once and persists.
-        /// </summary>
-        [System.Runtime.Versioning.SupportedOSPlatform("windows")]
-        private static void EnsureWindowsShortcut()
-        {
-            try
-            {
-                string startMenu = Path.Combine(
-                    Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
-                    "Microsoft", "Windows", "Start Menu", "Programs");
-                string shortcutPath = Path.Combine(startMenu, $"{AppDisplayName}.lnk");
-
-                if (File.Exists(shortcutPath))
-                {
-                    Logger.LogDebug("Start menu shortcut already exists at {Path}", shortcutPath);
-                    return;
-                }
-
-                // Create shortcut using COM IShellLink + IPropertyStore
-                string? exePath = Environment.ProcessPath;
-                if (string.IsNullOrEmpty(exePath)) return;
-
-                var shellLink = (IShellLinkW)new CShellLink();
-                shellLink.SetPath(exePath);
-                shellLink.SetDescription(AppDisplayName);
-
-                // Set the AUMID on the shortcut via IPropertyStore
-                var propertyStore = (IPropertyStore)shellLink;
-                var aumidKey = new PROPERTYKEY
-                {
-                    fmtid = new Guid("9F4C2855-9F79-4B39-A8D0-E1D42DE1D5F3"),
-                    pid = 5 // System.AppUserModel.ID
+                    Title = title,
+                    Body = message
                 };
-                var propVariant = new PROPVARIANT { vt = 31, pwszVal = Marshal.StringToCoTaskMemUni(AppId) };
-                propertyStore.SetValue(ref aumidKey, ref propVariant);
-                propertyStore.Commit();
 
-                var persistFile = (IPersistFile)shellLink;
-                persistFile.Save(shortcutPath, true);
-
-                Marshal.FreeCoTaskMem(propVariant.pwszVal);
-                Logger.LogInformation("Created Start menu shortcut with AUMID at {Path}", shortcutPath);
+                await s_manager!.ShowNotification(notification);
+                Logger.LogInformation("Native notification shown: {Title}", title);
             }
             catch (Exception ex)
             {
-                Logger.LogWarning(ex, "Failed to create Start menu shortcut for toast registration");
+                Logger.LogError(ex, "Failed to show native notification async");
             }
         }
-
-        private static void ShowLinux(string title, string message)
-        {
-            var process = Process.Start(new ProcessStartInfo
-            {
-                FileName = "notify-send",
-                ArgumentList = { "--app-name", AppDisplayName, title, message },
-                CreateNoWindow = true,
-                UseShellExecute = false
-            });
-            Logger.LogInformation("notify-send launched (PID {Pid})", process?.Id ?? -1);
-        }
-
-        private static void ShowMacOS(string title, string message)
-        {
-            string escapedTitle = title.Replace("\\", "\\\\").Replace("\"", "\\\"");
-            string escapedMessage = message.Replace("\\", "\\\\").Replace("\"", "\\\"");
-
-            var process = Process.Start(new ProcessStartInfo
-            {
-                FileName = "osascript",
-                ArgumentList =
-                {
-                    "-e",
-                    $"display notification \"{escapedMessage}\" with title \"{escapedTitle}\""
-                },
-                CreateNoWindow = true,
-                UseShellExecute = false
-            });
-            Logger.LogInformation("osascript launched (PID {Pid})", process?.Id ?? -1);
-        }
-
-        private static string EscapeXml(string text)
-        {
-            return text
-                .Replace("&", "&amp;")
-                .Replace("<", "&lt;")
-                .Replace(">", "&gt;")
-                .Replace("\"", "&quot;")
-                .Replace("'", "&apos;");
-        }
-
-        #region Windows COM Interop for IShellLink + IPropertyStore
-
-        [ComImport]
-        [Guid("00021401-0000-0000-C000-000000000046")]
-        private class CShellLink { }
-
-        [ComImport]
-        [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
-        [Guid("000214F9-0000-0000-C000-000000000046")]
-        private interface IShellLinkW
-        {
-            void GetPath(IntPtr pszFile, int cch, IntPtr pfd, int fFlags);
-            void GetIDList(out IntPtr ppidl);
-            void SetIDList(IntPtr pidl);
-            void GetDescription(IntPtr pszName, int cch);
-            void SetDescription([MarshalAs(UnmanagedType.LPWStr)] string pszName);
-            void GetWorkingDirectory(IntPtr pszDir, int cch);
-            void SetWorkingDirectory([MarshalAs(UnmanagedType.LPWStr)] string pszDir);
-            void GetArguments(IntPtr pszArgs, int cch);
-            void SetArguments([MarshalAs(UnmanagedType.LPWStr)] string pszArgs);
-            void GetHotkey(out short pwHotkey);
-            void SetHotkey(short wHotkey);
-            void GetShowCmd(out int piShowCmd);
-            void SetShowCmd(int iShowCmd);
-            void GetIconLocation(IntPtr pszIconPath, int cch, out int piIcon);
-            void SetIconLocation([MarshalAs(UnmanagedType.LPWStr)] string pszIconPath, int iIcon);
-            void SetRelativePath([MarshalAs(UnmanagedType.LPWStr)] string pszPathRel, int dwReserved);
-            void Resolve(IntPtr hwnd, int fFlags);
-            void SetPath([MarshalAs(UnmanagedType.LPWStr)] string pszFile);
-        }
-
-        [ComImport]
-        [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
-        [Guid("886D8EEB-8CF2-4446-8D02-CDBA1DBDCF99")]
-        private interface IPropertyStore
-        {
-            void GetCount(out uint cProps);
-            void GetAt(uint iProp, out PROPERTYKEY pkey);
-            void GetValue(ref PROPERTYKEY key, out PROPVARIANT pv);
-            void SetValue(ref PROPERTYKEY key, ref PROPVARIANT propvar);
-            void Commit();
-        }
-
-        [ComImport]
-        [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
-        [Guid("0000010B-0000-0000-C000-000000000046")]
-        private interface IPersistFile
-        {
-            void GetCurFile(out IntPtr ppszFileName);
-            void IsDirty();
-            void Load([MarshalAs(UnmanagedType.LPWStr)] string pszFileName, int dwMode);
-            void Save([MarshalAs(UnmanagedType.LPWStr)] string pszFileName, [MarshalAs(UnmanagedType.Bool)] bool fRemember);
-            void SaveCompleted([MarshalAs(UnmanagedType.LPWStr)] string pszFileName);
-        }
-
-        [StructLayout(LayoutKind.Sequential)]
-        private struct PROPERTYKEY
-        {
-            public Guid fmtid;
-            public uint pid;
-        }
-
-        [StructLayout(LayoutKind.Sequential)]
-        private struct PROPVARIANT
-        {
-            public ushort vt;
-            public ushort wReserved1;
-            public ushort wReserved2;
-            public ushort wReserved3;
-            public IntPtr pwszVal;
-        }
-
-        #endregion
     }
 }

--- a/src/EveLens.Avalonia/Views/CharacterMonitor/CharacterMonitorView.axaml
+++ b/src/EveLens.Avalonia/Views/CharacterMonitor/CharacterMonitorView.axaml
@@ -81,6 +81,9 @@
                 <TabItem x:Name="TabKills" Header="Kills" FontSize="{DynamicResource EveFontBody}">
                     <local:CharacterKillLogView />
                 </TabItem>
+                <TabItem x:Name="TabPI" Header="Planetary (Beta)" FontSize="{DynamicResource EveFontBody}">
+                    <local:CharacterPlanetaryView />
+                </TabItem>
             </TabControl>
 
             <!-- Gear button — inline with tab strip at top-right -->

--- a/src/EveLens.Avalonia/Views/CharacterMonitor/CharacterOverviewView.axaml
+++ b/src/EveLens.Avalonia/Views/CharacterMonitor/CharacterOverviewView.axaml
@@ -2,7 +2,11 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              x:Class="EveLens.Avalonia.Views.CharacterMonitor.CharacterOverviewView">
 
-    <ScrollViewer HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Auto">
-        <StackPanel x:Name="OverviewPanel" Margin="16,12" Spacing="8" />
-    </ScrollViewer>
+    <Panel>
+        <ScrollViewer x:Name="OverviewScroller" HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Auto">
+            <StackPanel x:Name="OverviewPanel" Margin="16,12" Spacing="8" />
+        </ScrollViewer>
+        <Canvas x:Name="DragCanvas" IsHitTestVisible="False"
+                HorizontalAlignment="Stretch" VerticalAlignment="Stretch" />
+    </Panel>
 </UserControl>

--- a/src/EveLens.Avalonia/Views/CharacterMonitor/CharacterOverviewView.axaml.cs
+++ b/src/EveLens.Avalonia/Views/CharacterMonitor/CharacterOverviewView.axaml.cs
@@ -11,6 +11,7 @@ using Avalonia;
 using Avalonia.Animation.Easings;
 using Avalonia.Controls;
 using Avalonia.Controls.Shapes;
+using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.Layout;
 using Avalonia.Media;
@@ -29,8 +30,6 @@ using EveLens.Common.Services;
 using EveLens.Common.SettingsObjects;
 using EveLens.Common.ViewModels;
 using EveLens.Avalonia.Views.Dialogs;
-using EveLens.Core.Events;
-
 using EveLens.Core.Events;
 using EveLens.Avalonia.Services;
 namespace EveLens.Avalonia.Views.CharacterMonitor
@@ -57,12 +56,30 @@ namespace EveLens.Avalonia.Views.CharacterMonitor
         // Toggle for fetching dot pulse (alternates each second tick)
         private bool _fetchingDotBright;
 
+        // Reorder mode — when active, cards are draggable instead of clickable
+        private bool _reorderMode;
+        private Button? _reorderToggleBtn;
+
         // Only animate the staggered fade-in on first application load
         private bool _initialLoadDone;
 
         // Track collapsed groups for expand/collapse persistence
         private const string OverviewCollapseKey = "OverviewGroups";
         private HashSet<string> _collapsedGroups = new(StringComparer.Ordinal);
+
+        // Drag-to-reorder state
+        private bool _isDragging;
+        private bool _dragPending;
+        private double _dragStartX, _dragStartY;
+        private int _dragStartIndex = -1;
+        private WrapPanel? _dragSourcePanel;
+        private Button? _draggedCard;
+        private Border? _dragGhost;
+        private Border? _insertIndicator;
+        private int _currentInsertIndex = -1;
+        private string? _dragGroupName;
+        private const double DragThreshold = 8.0;
+        private const double CardWidth = 308.0; // 300 + 8 margin
 
 
         public CharacterOverviewView()
@@ -137,6 +154,9 @@ namespace EveLens.Avalonia.Views.CharacterMonitor
 
                 OverviewPanel.Children.Clear();
 
+                // Reorder mode toolbar
+                BuildReorderToolbar();
+
                 // Load persisted collapse state — we store collapsed group names
                 _collapsedGroups = CollapseStateHelper.LoadExpandState(0, OverviewCollapseKey);
                 _prevBalances.Clear();
@@ -179,6 +199,7 @@ namespace EveLens.Avalonia.Views.CharacterMonitor
                     var ungrouped = characters.Where(c => !assignedGuids.Contains(c.Guid)).ToList();
                     if (ungrouped.Count > 0)
                     {
+                        ungrouped = SortByUngroupedOrder(ungrouped);
                         BuildGroupSection("Ungrouped", ungrouped, ref cardIndex);
                     }
 
@@ -189,7 +210,8 @@ namespace EveLens.Avalonia.Views.CharacterMonitor
                 }
                 else
                 {
-                    var wrap = BuildCardWrapPanel(characters, ref cardIndex, includeGhostCard: true);
+                    characters = SortByUngroupedOrder(characters);
+                    var wrap = BuildCardWrapPanel(characters, ref cardIndex, includeGhostCard: true, groupName: "Ungrouped");
                     OverviewPanel.Children.Add(wrap);
                 }
 
@@ -266,7 +288,7 @@ namespace EveLens.Avalonia.Views.CharacterMonitor
             divider.Children.Add(count);
             divider.Children.Add(line);
 
-            var wrap = BuildCardWrapPanel(characters, ref cardIndex);
+            var wrap = BuildCardWrapPanel(characters, ref cardIndex, groupName: groupName);
             wrap.IsVisible = !isCollapsed;
 
             // Click header to toggle collapse
@@ -288,13 +310,14 @@ namespace EveLens.Avalonia.Views.CharacterMonitor
         }
 
         private WrapPanel BuildCardWrapPanel(List<Character> characters, ref int cardIndex,
-            bool includeGhostCard = false)
+            bool includeGhostCard = false, string? groupName = null)
         {
-            var wrap = new WrapPanel { Orientation = Orientation.Horizontal };
+            var wrap = new WrapPanel { Orientation = Orientation.Horizontal, Tag = groupName };
 
             foreach (var character in characters)
             {
                 var card = BuildCharacterCard(character, cardIndex);
+                card.AddHandler(PointerPressedEvent, OnCardPointerPressed, global::Avalonia.Interactivity.RoutingStrategies.Tunnel);
                 wrap.Children.Add(card);
                 cardIndex++;
             }
@@ -1334,6 +1357,8 @@ namespace EveLens.Avalonia.Views.CharacterMonitor
         {
             try
             {
+                if (_reorderMode) return;
+
                 if (sender is Button btn && btn.DataContext is Character character)
                 {
                     var mainWindow = this.FindAncestorOfType<MainWindow>();
@@ -1344,6 +1369,525 @@ namespace EveLens.Avalonia.Views.CharacterMonitor
             {
                 System.Diagnostics.Debug.WriteLine($"Card click error: {ex}");
             }
+        }
+
+        #endregion
+
+        #region Drag-to-Reorder
+
+        private void BuildReorderToolbar()
+        {
+            var characters = AppServices.Characters.Where(c => c.Monitored).ToList();
+            if (characters.Count < 2) return;
+
+            _reorderToggleBtn = new Button
+            {
+                Content = _reorderMode ? "Done" : "Reorder",
+                FontSize = FontScaleService.Small,
+                Padding = new Thickness(10, 3),
+                CornerRadius = new CornerRadius(12),
+                Background = _reorderMode
+                    ? FindBrush("EveAccentPrimaryBrush", Brushes.Gold)
+                    : Brushes.Transparent,
+                Foreground = _reorderMode
+                    ? Brushes.Black
+                    : FindBrush("EveTextSecondaryBrush", Brushes.Gray),
+                HorizontalAlignment = HorizontalAlignment.Right,
+                Cursor = new global::Avalonia.Input.Cursor(global::Avalonia.Input.StandardCursorType.Hand)
+            };
+            _reorderToggleBtn.Click += OnReorderToggle;
+
+            var manageGroupsBtn = new Button
+            {
+                Content = "Manage Groups",
+                FontSize = FontScaleService.Small,
+                Padding = new Thickness(10, 3),
+                CornerRadius = new CornerRadius(12),
+                Background = Brushes.Transparent,
+                Foreground = FindBrush("EveTextSecondaryBrush", Brushes.Gray),
+                HorizontalAlignment = HorizontalAlignment.Right,
+                Margin = new Thickness(0, 0, 6, 0),
+                Cursor = new global::Avalonia.Input.Cursor(global::Avalonia.Input.StandardCursorType.Hand)
+            };
+            manageGroupsBtn.Click += OnManageGroupsClick;
+
+            var toolbar = new DockPanel { Margin = new Thickness(0, 0, 0, 4) };
+            if (_reorderMode)
+            {
+                toolbar.Children.Add(new TextBlock
+                {
+                    Text = "Drag cards to reorder, then click Done",
+                    FontSize = FontScaleService.Small,
+                    Foreground = FindBrush("EveAccentPrimaryBrush", Brushes.Gold),
+                    VerticalAlignment = VerticalAlignment.Center,
+                    FontStyle = FontStyle.Italic
+                });
+            }
+
+            var btnPanel = new StackPanel { Orientation = Orientation.Horizontal, HorizontalAlignment = HorizontalAlignment.Right };
+            btnPanel.Children.Add(manageGroupsBtn);
+            btnPanel.Children.Add(_reorderToggleBtn);
+            DockPanel.SetDock(btnPanel, Dock.Right);
+            toolbar.Children.Insert(0, btnPanel);
+
+            OverviewPanel.Children.Add(toolbar);
+        }
+
+        private void OnManageGroupsClick(object? sender, RoutedEventArgs e)
+        {
+            var mainWindow = this.FindAncestorOfType<MainWindow>();
+            if (mainWindow == null) return;
+
+            var dialog = new ManageGroupsWindow { };
+            dialog.ShowDialog(mainWindow);
+        }
+
+        private void OnReorderToggle(object? sender, RoutedEventArgs e)
+        {
+            _reorderMode = !_reorderMode;
+            LoadData();
+        }
+
+        private static List<Character> SortByUngroupedOrder(List<Character> characters)
+        {
+            var order = Settings.UngroupedCharacterOrder;
+            if (order == null || order.Count == 0)
+                return characters;
+
+            var orderMap = new Dictionary<Guid, int>();
+            for (int i = 0; i < order.Count; i++)
+                orderMap[order[i]] = i;
+
+            return characters
+                .OrderBy(c => orderMap.TryGetValue(c.Guid, out int idx) ? idx : int.MaxValue)
+                .ThenBy(c => c.Name)
+                .ToList();
+        }
+
+        private void OnCardPointerPressed(object? sender, PointerPressedEventArgs e)
+        {
+            try
+            {
+                if (!_reorderMode) return;
+
+                if (e.GetCurrentPoint(this).Properties.IsLeftButtonPressed == false)
+                    return;
+
+                if (sender is not Button card || card.DataContext is not Character)
+                    return;
+
+                var wrap = card.Parent as WrapPanel;
+                if (wrap == null) return;
+
+                var pos = e.GetPosition(OverviewScroller);
+                _dragPending = true;
+                _dragStartX = pos.X;
+                _dragStartY = pos.Y;
+                _draggedCard = card;
+                _dragSourcePanel = wrap;
+                _dragGroupName = wrap.Tag as string;
+                _dragStartIndex = GetCardIndex(wrap, card);
+
+                e.Pointer.Capture(OverviewScroller);
+                e.Handled = true;
+
+                OverviewScroller.PointerMoved += OnPendingDragPointerMoved;
+                OverviewScroller.PointerReleased += OnPendingDragPointerReleased;
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"Drag press error: {ex}");
+            }
+        }
+
+        private void OnPendingDragPointerMoved(object? sender, PointerEventArgs e)
+        {
+            if (!_dragPending) return;
+
+            var pos = e.GetPosition(OverviewScroller);
+            double dx = Math.Abs(pos.X - _dragStartX);
+            double dy = Math.Abs(pos.Y - _dragStartY);
+
+            if (dx < DragThreshold && dy < DragThreshold) return;
+
+            // Promote to real drag
+            _dragPending = false;
+            OverviewScroller.PointerMoved -= OnPendingDragPointerMoved;
+            OverviewScroller.PointerReleased -= OnPendingDragPointerReleased;
+
+            PromoteToDrag(e);
+        }
+
+        private void OnPendingDragPointerReleased(object? sender, PointerReleasedEventArgs e)
+        {
+            // Did not exceed threshold — not a drag, allow click to proceed
+            _dragPending = false;
+            OverviewScroller.PointerMoved -= OnPendingDragPointerMoved;
+            OverviewScroller.PointerReleased -= OnPendingDragPointerReleased;
+            e.Pointer.Capture(null);
+            _draggedCard = null;
+            _dragSourcePanel = null;
+            _dragStartIndex = -1;
+        }
+
+        private void PromoteToDrag(PointerEventArgs e)
+        {
+            _isDragging = true;
+
+            // Ghost the dragged card — smooth fade out
+            if (_draggedCard != null)
+            {
+                _draggedCard.Opacity = 0.2;
+                _draggedCard.RenderTransform = global::Avalonia.Media.Transformation.TransformOperations.Parse("scale(0.95)");
+            }
+
+            // Create ghost badge with character name
+            string label = (_draggedCard?.DataContext as Character)?.Name ?? "Character";
+            _dragGhost = new Border
+            {
+                Background = new SolidColorBrush(Color.Parse("#E81A1F2E")),
+                BorderBrush = FindBrush("EveAccentPrimaryBrush", Brushes.Gold),
+                BorderThickness = new Thickness(1.5),
+                CornerRadius = new CornerRadius(8),
+                Padding = new Thickness(14, 8),
+                IsHitTestVisible = false,
+                BoxShadow = new BoxShadows(new BoxShadow { Blur = 12, Color = Color.Parse("#60000000") }),
+                Child = new TextBlock
+                {
+                    Text = label,
+                    FontSize = FontScaleService.Body,
+                    Foreground = FindBrush("EveAccentPrimaryBrush", Brushes.Gold),
+                    FontWeight = FontWeight.SemiBold,
+                },
+            };
+
+            var viewPos = e.GetPosition(OverviewScroller);
+            Canvas.SetLeft(_dragGhost, viewPos.X + 16);
+            Canvas.SetTop(_dragGhost, viewPos.Y - 12);
+            DragCanvas.Children.Add(_dragGhost);
+
+            // Create insert indicator (vertical line between cards)
+            _insertIndicator = new Border
+            {
+                Width = 3,
+                Height = 90,
+                Background = new SolidColorBrush(Color.Parse("#4A94F0")),
+                CornerRadius = new CornerRadius(2),
+                IsHitTestVisible = false,
+                IsVisible = false
+            };
+            DragCanvas.Children.Add(_insertIndicator);
+
+            // Capture pointer on the scroller
+            e.Pointer.Capture(OverviewScroller);
+            OverviewScroller.PointerMoved += OnDragPointerMoved;
+            OverviewScroller.PointerReleased += OnDragPointerReleased;
+        }
+
+        private void OnDragPointerMoved(object? sender, PointerEventArgs e)
+        {
+            if (!_isDragging || _dragSourcePanel == null) return;
+
+            try
+            {
+                var viewPos = e.GetPosition(OverviewScroller);
+
+                // Move ghost
+                if (_dragGhost != null)
+                {
+                    Canvas.SetLeft(_dragGhost, viewPos.X + 16);
+                    Canvas.SetTop(_dragGhost, viewPos.Y - 12);
+                }
+
+                // Auto-scroll near edges
+                double scrollZone = 40;
+                double viewportHeight = OverviewScroller.Bounds.Height;
+                if (viewPos.Y < scrollZone)
+                {
+                    double speed = (scrollZone - viewPos.Y) / scrollZone * 6;
+                    OverviewScroller.Offset = new Vector(0, Math.Max(0, OverviewScroller.Offset.Y - speed));
+                }
+                else if (viewPos.Y > viewportHeight - scrollZone)
+                {
+                    double speed = (viewPos.Y - (viewportHeight - scrollZone)) / scrollZone * 6;
+                    double maxScroll = OverviewScroller.Extent.Height - viewportHeight;
+                    OverviewScroller.Offset = new Vector(0, Math.Min(maxScroll, OverviewScroller.Offset.Y + speed));
+                }
+
+                // Calculate insert position within the source WrapPanel
+                var panelPos = e.GetPosition(_dragSourcePanel);
+                int insertIndex = CalculateInsertIndex(_dragSourcePanel, panelPos);
+
+                if (insertIndex == _currentInsertIndex) return;
+                _currentInsertIndex = insertIndex;
+
+                // Position the insert indicator
+                UpdateInsertIndicator(insertIndex);
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"Drag move error: {ex}");
+            }
+        }
+
+        private void OnDragPointerReleased(object? sender, PointerReleasedEventArgs e)
+        {
+            if (!_isDragging) return;
+
+            try
+            {
+                // Right-click cancels
+                if (e.InitialPressMouseButton == MouseButton.Right)
+                {
+                    CancelDrag(e.Pointer);
+                    return;
+                }
+
+                // Cleanup event subscriptions
+                OverviewScroller.PointerMoved -= OnDragPointerMoved;
+                OverviewScroller.PointerReleased -= OnDragPointerReleased;
+                e.Pointer.Capture(null);
+
+                // Remove ghost and indicator
+                CleanupDragVisuals();
+
+                // Restore card opacity
+                if (_draggedCard != null)
+                {
+                    _draggedCard.Opacity = 1.0;
+                    _draggedCard.RenderTransform = null;
+                }
+
+                // Perform the reorder if we have a valid drop position
+                if (_currentInsertIndex >= 0 && _dragSourcePanel != null && _dragStartIndex >= 0)
+                {
+                    int fromIndex = _dragStartIndex;
+                    int toIndex = _currentInsertIndex;
+
+                    // Adjust target: if moving forward, account for the removal of the source
+                    if (toIndex > fromIndex)
+                        toIndex--;
+
+                    if (toIndex != fromIndex)
+                    {
+                        PerformReorder(fromIndex, toIndex);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"Drag release error: {ex}");
+            }
+            finally
+            {
+                ResetDragState();
+            }
+        }
+
+        private void CancelDrag(IPointer pointer)
+        {
+            OverviewScroller.PointerMoved -= OnDragPointerMoved;
+            OverviewScroller.PointerReleased -= OnDragPointerReleased;
+            pointer.Capture(null);
+            CleanupDragVisuals();
+
+            if (_draggedCard != null)
+                _draggedCard.Opacity = 1.0;
+
+            ResetDragState();
+        }
+
+        private void CleanupDragVisuals()
+        {
+            if (_dragGhost != null)
+            {
+                DragCanvas.Children.Remove(_dragGhost);
+                _dragGhost = null;
+            }
+            if (_insertIndicator != null)
+            {
+                DragCanvas.Children.Remove(_insertIndicator);
+                _insertIndicator = null;
+            }
+        }
+
+        private void ResetDragState()
+        {
+            _isDragging = false;
+            _dragPending = false;
+            _draggedCard = null;
+            _dragSourcePanel = null;
+            _dragStartIndex = -1;
+            _currentInsertIndex = -1;
+            _dragGroupName = null;
+        }
+
+        private int CalculateInsertIndex(WrapPanel panel, Point posInPanel)
+        {
+            // Count only character cards (exclude ghost card)
+            int cardCount = 0;
+            for (int i = 0; i < panel.Children.Count; i++)
+            {
+                if (panel.Children[i] is Button btn && btn.DataContext is Character)
+                    cardCount++;
+            }
+
+            if (cardCount == 0) return 0;
+
+            // Use actual card bounds for accurate hit detection
+            for (int i = 0; i < panel.Children.Count; i++)
+            {
+                if (panel.Children[i] is not Button btn || btn.DataContext is not Character)
+                    continue;
+
+                var bounds = btn.Bounds;
+                double cardMidX = bounds.X + bounds.Width / 2;
+
+                // Check if pointer is within this card's vertical band
+                if (posInPanel.Y >= bounds.Y && posInPanel.Y < bounds.Y + bounds.Height)
+                {
+                    if (posInPanel.X < cardMidX)
+                        return i;
+                }
+            }
+
+            // If pointer is below or to the right of all cards, insert at end
+            return cardCount;
+        }
+
+        private void UpdateInsertIndicator(int insertIndex)
+        {
+            if (_insertIndicator == null || _dragSourcePanel == null) return;
+
+            // Get the position of the insert point in scroller coordinates
+            int charCardIndex = 0;
+            Button? targetCard = null;
+            bool insertAtEnd = true;
+
+            for (int i = 0; i < _dragSourcePanel.Children.Count; i++)
+            {
+                if (_dragSourcePanel.Children[i] is not Button btn || btn.DataContext is not Character)
+                    continue;
+
+                if (charCardIndex == insertIndex)
+                {
+                    targetCard = btn;
+                    insertAtEnd = false;
+                    break;
+                }
+                charCardIndex++;
+            }
+
+            Point indicatorPos;
+            if (targetCard != null)
+            {
+                // Position to the left of this card
+                var cardTopLeft = targetCard.TranslatePoint(new Point(0, 0), OverviewScroller);
+                if (cardTopLeft == null)
+                {
+                    _insertIndicator.IsVisible = false;
+                    return;
+                }
+                indicatorPos = cardTopLeft.Value;
+            }
+            else if (insertAtEnd)
+            {
+                // Position to the right of the last card
+                Button? lastCard = null;
+                for (int i = _dragSourcePanel.Children.Count - 1; i >= 0; i--)
+                {
+                    if (_dragSourcePanel.Children[i] is Button btn && btn.DataContext is Character)
+                    {
+                        lastCard = btn;
+                        break;
+                    }
+                }
+                if (lastCard == null)
+                {
+                    _insertIndicator.IsVisible = false;
+                    return;
+                }
+                var lastTopLeft = lastCard.TranslatePoint(new Point(lastCard.Bounds.Width, 0), OverviewScroller);
+                if (lastTopLeft == null)
+                {
+                    _insertIndicator.IsVisible = false;
+                    return;
+                }
+                indicatorPos = lastTopLeft.Value;
+            }
+            else
+            {
+                _insertIndicator.IsVisible = false;
+                return;
+            }
+
+            _insertIndicator.Height = 90;
+            Canvas.SetLeft(_insertIndicator, indicatorPos.X - 1);
+            Canvas.SetTop(_insertIndicator, indicatorPos.Y);
+            _insertIndicator.IsVisible = true;
+        }
+
+        private void PerformReorder(int fromIndex, int toIndex)
+        {
+            if (_dragGroupName == null || _dragSourcePanel == null) return;
+
+            if (_dragGroupName == "Ungrouped")
+            {
+                // Reorder in UngroupedCharacterOrder
+                var characters = GetCharactersFromPanel(_dragSourcePanel);
+                if (fromIndex >= characters.Count) return;
+
+                var movedChar = characters[fromIndex];
+                characters.RemoveAt(fromIndex);
+                if (toIndex > characters.Count) toIndex = characters.Count;
+                characters.Insert(toIndex, movedChar);
+
+                // Update the settings list
+                Settings.UngroupedCharacterOrder = characters.Select(c => c.Guid).ToList();
+            }
+            else
+            {
+                // Reorder within a named group's CharacterGuids
+                var group = Settings.CharacterGroups.FirstOrDefault(g => g.Name == _dragGroupName);
+                if (group == null) return;
+
+                var guids = group.CharacterGuids;
+                if (fromIndex >= guids.Count) return;
+
+                var movedGuid = guids[fromIndex];
+                guids.RemoveAt(fromIndex);
+                if (toIndex > guids.Count) toIndex = guids.Count;
+                guids.Insert(toIndex, movedGuid);
+            }
+
+            // Persist and notify
+            Settings.Save();
+            AppServices.EventAggregator?.Publish(Common.Events.SettingsChangedEvent.Instance);
+        }
+
+        private static List<Character> GetCharactersFromPanel(WrapPanel panel)
+        {
+            var result = new List<Character>();
+            foreach (var child in panel.Children)
+            {
+                if (child is Button btn && btn.DataContext is Character ch)
+                    result.Add(ch);
+            }
+            return result;
+        }
+
+        private static int GetCardIndex(WrapPanel panel, Button card)
+        {
+            int index = 0;
+            foreach (var child in panel.Children)
+            {
+                if (child is Button btn && btn.DataContext is Character)
+                {
+                    if (btn == card) return index;
+                    index++;
+                }
+            }
+            return -1;
         }
 
         #endregion

--- a/src/EveLens.Avalonia/Views/CharacterMonitor/CharacterOverviewView.axaml.cs
+++ b/src/EveLens.Avalonia/Views/CharacterMonitor/CharacterOverviewView.axaml.cs
@@ -492,12 +492,18 @@ namespace EveLens.Avalonia.Views.CharacterMonitor
             };
 
             // Grid overlays the dot on the portrait
-            var portraitContainer = new Grid
+            var portraitGrid = new Grid
             {
                 Width = 56, Height = 56,
+                Children = { portraitBorder, esiDot }
+            };
+
+            var portraitContainer = new StackPanel
+            {
+                Spacing = 0,
                 VerticalAlignment = VerticalAlignment.Top,
                 Margin = new Thickness(0, 0, 12, 0),
-                Children = { portraitBorder, esiDot }
+                Children = { portraitGrid }
             };
 
             // Info panel
@@ -547,7 +553,26 @@ namespace EveLens.Avalonia.Views.CharacterMonitor
             };
             infoPanel.Children.Add(spText);
 
-            // Account status badge
+            // Location + Ship line
+            string locationName = character.LastKnownSolarSystem?.Name ?? "";
+            string shipType = character.ShipTypeName ?? "";
+            if (!string.IsNullOrEmpty(locationName) || !string.IsNullOrEmpty(shipType))
+            {
+                string locShipText = !string.IsNullOrEmpty(locationName) && !string.IsNullOrEmpty(shipType)
+                    ? $"{locationName} \u2022 {shipType}"
+                    : !string.IsNullOrEmpty(locationName) ? locationName : shipType;
+
+                infoPanel.Children.Add(new TextBlock
+                {
+                    Text = locShipText,
+                    FontSize = FontScaleService.Small,
+                    Foreground = FindBrush("EveTextDisabledBrush", Brushes.Gray),
+                    TextTrimming = TextTrimming.CharacterEllipsis,
+                    Tag = "LocationShipText"
+                });
+            }
+
+            // Account status badge \u2014 built here, added below portrait later
             bool isOmega = character.EffectiveCharacterStatus == AccountStatus.Omega;
             var badgeText = new TextBlock
             {
@@ -555,20 +580,20 @@ namespace EveLens.Avalonia.Views.CharacterMonitor
                 FontSize = FontScaleService.Caption, FontWeight = FontWeight.SemiBold,
                 Foreground = isOmega
                     ? new SolidColorBrush(Color.Parse("#FF00C853"))
-                    : new SolidColorBrush(Color.Parse("#FFFF6D00"))
+                    : new SolidColorBrush(Color.Parse("#FFFF6D00")),
+                HorizontalAlignment = HorizontalAlignment.Center
             };
             var badge = new Border
             {
                 CornerRadius = new CornerRadius(8),
                 Padding = new Thickness(6, 1),
-                HorizontalAlignment = HorizontalAlignment.Left,
-                Margin = new Thickness(0, 1, 0, 0),
+                HorizontalAlignment = HorizontalAlignment.Center,
+                Margin = new Thickness(0, 3, 0, 0),
                 Background = isOmega
                     ? new SolidColorBrush(Color.Parse("#2200C853"))
                     : new SolidColorBrush(Color.Parse("#22FF6D00")),
                 Child = badgeText
             };
-            infoPanel.Children.Add(badge);
 
             // Training status
             var trainingText = new TextBlock
@@ -580,6 +605,9 @@ namespace EveLens.Avalonia.Views.CharacterMonitor
             };
             UpdateTrainingText(trainingText, character);
             infoPanel.Children.Add(trainingText);
+
+            // Add Omega/Alpha badge below portrait
+            portraitContainer.Children.Add(badge);
 
             var cardGrid = new Grid { ColumnDefinitions = ColumnDefinitions.Parse("68,*") };
             Grid.SetColumn(portraitContainer, 0);
@@ -831,6 +859,19 @@ namespace EveLens.Avalonia.Views.CharacterMonitor
                         if (!PrivacyHelper.IsSkillPointsHidden) FlashTextBlock(spBlock);
                     }
                     _prevSkillPoints[character.CharacterID] = character.SkillPoints;
+                }
+
+                // Update location + ship
+                var locShipBlock = FindTaggedDescendant<TextBlock>(card, "LocationShipText");
+                if (locShipBlock != null)
+                {
+                    string locationName = character.LastKnownSolarSystem?.Name ?? "";
+                    string shipType = character.ShipTypeName ?? "";
+                    string locShipText = !string.IsNullOrEmpty(locationName) && !string.IsNullOrEmpty(shipType)
+                        ? $"{locationName} • {shipType}"
+                        : !string.IsNullOrEmpty(locationName) ? locationName : shipType;
+                    if (locShipBlock.Text != locShipText)
+                        locShipBlock.Text = locShipText;
                 }
 
                 // Update training text

--- a/src/EveLens.Avalonia/Views/CharacterMonitor/CharacterPlanetaryView.axaml
+++ b/src/EveLens.Avalonia/Views/CharacterMonitor/CharacterPlanetaryView.axaml
@@ -29,64 +29,113 @@
                            Foreground="{DynamicResource EveTextSecondaryBrush}" HorizontalAlignment="Center" />
                 <TextBlock x:Name="ScopeSubtext" TextWrapping="Wrap" TextAlignment="Center" FontSize="{DynamicResource EveFontBody}"
                            Foreground="{DynamicResource EveTextDisabledBrush}" HorizontalAlignment="Center"
-                           Text="This character was authenticated without the required scope.&#x0a;Re-authenticate from File → Manage Characters to enable this feature." />
+                           Text="This character was authenticated without the required scope.&#x0a;Re-authenticate from File > Manage Characters to enable this feature." />
             </StackPanel>
         </Border>
 
         <DockPanel x:Name="DataContent">
-        <!-- Filter bar -->
-        <Border DockPanel.Dock="Top" Padding="8,4"
-                Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}">
-            <DockPanel>
-                <TextBlock x:Name="FilterLabel" Text="Filter:" VerticalAlignment="Center" Margin="0,0,8,0" />
-                <TextBox x:Name="FilterBox"
-                         Text="{Binding TextFilter, Mode=TwoWay}"
-                         Watermark="Search planetary..."
-                         MinWidth="200" />
+            <!-- Toolbar -->
+            <Border DockPanel.Dock="Top" Padding="10,7"
+                    Background="{DynamicResource EveBackgroundMediumBrush}">
+                <DockPanel>
+                    <!-- View toggle buttons -->
+                    <StackPanel DockPanel.Dock="Left" Orientation="Horizontal" Spacing="6">
+                        <Button x:Name="DashboardToggle" Content="Dashboard"
+                                FontSize="{DynamicResource EveFontBody}" Padding="10,4" CornerRadius="12"
+                                Click="OnToggleDashboard" />
+                        <Button x:Name="DataToggle" Content="Data"
+                                FontSize="{DynamicResource EveFontBody}" Padding="10,4" CornerRadius="12"
+                                Click="OnToggleData" />
+                    </StackPanel>
+
+                    <!-- Filter -->
+                    <Border DockPanel.Dock="Right" CornerRadius="14" Padding="8,3"
+                            Background="{DynamicResource EveBackgroundDarkBrush}" MinWidth="200">
+                        <DockPanel>
+                            <Button x:Name="ClearFilterBtn" DockPanel.Dock="Right" Content="x"
+                                    FontSize="{DynamicResource EveFontSmall}" Padding="4,2" Background="Transparent"
+                                    BorderThickness="0" IsVisible="False"
+                                    Click="OnClearFilter" />
+                            <TextBox x:Name="FilterBox" Watermark="Search planets..."
+                                     Background="Transparent" BorderThickness="0"
+                                     FontSize="{DynamicResource EveFontBody}"
+                                     TextChanged="OnFilterChanged" />
+                        </DockPanel>
+                    </Border>
+
+                    <Panel /> <!-- spacer -->
+                </DockPanel>
+            </Border>
+
+            <!-- Status bar -->
+            <Border DockPanel.Dock="Bottom" Padding="10,4"
+                    Background="{DynamicResource EveBackgroundMediumBrush}"
+                    BorderThickness="0,1,0,0"
+                    BorderBrush="{DynamicResource EveBackgroundDarkBrush}">
+                <TextBlock x:Name="StatusBar"
+                           FontSize="{DynamicResource EveFontBody}"
+                           Foreground="{DynamicResource EveTextSecondaryBrush}" />
+            </Border>
+
+            <!-- Dashboard view: cards grid (default) -->
+            <ScrollViewer x:Name="DashboardPanel">
+                <WrapPanel x:Name="CardsPanel" Orientation="Horizontal" Margin="10,8" />
+            </ScrollViewer>
+
+            <!-- Detail view: replaces cards when a colony is clicked -->
+            <DockPanel x:Name="DetailPanel" IsVisible="False">
+                <!-- Detail header with back button -->
+                <Border DockPanel.Dock="Top" Padding="10,6"
+                        Background="{DynamicResource EveBackgroundMediumBrush}">
+                    <DockPanel>
+                        <Button x:Name="BackBtn" DockPanel.Dock="Left" Content="Back"
+                                FontSize="{DynamicResource EveFontBody}" Padding="10,4" CornerRadius="12"
+                                Click="OnBackToCards" Margin="0,0,12,0" />
+                        <TextBlock x:Name="DetailTitle" Text=""
+                                   FontSize="{DynamicResource EveFontSubheading}" FontWeight="SemiBold"
+                                   Foreground="{DynamicResource EveAccentPrimaryBrush}"
+                                   VerticalAlignment="Center" />
+                    </DockPanel>
+                </Border>
+
+                <!-- Detail content: economics summary + flow canvas -->
+                <ScrollViewer>
+                    <StackPanel Margin="10,8" Spacing="12">
+                        <!-- Timer hero + economics summary row -->
+                        <Border Background="{DynamicResource EveBackgroundMediumBrush}"
+                                CornerRadius="6" Padding="12,10">
+                            <WrapPanel x:Name="DetailStatsPanel" Orientation="Horizontal" />
+                        </Border>
+
+                        <!-- Production chain canvas -->
+                        <Border Background="{DynamicResource EveBackgroundDarkBrush}"
+                                CornerRadius="6" MinHeight="280" Padding="0">
+                            <ContentControl x:Name="FlowCanvasHost" />
+                        </Border>
+                    </StackPanel>
+                </ScrollViewer>
             </DockPanel>
-        </Border>
 
-        <!-- Status bar -->
-        <Border DockPanel.Dock="Bottom" Padding="8,4"
-                Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}">
-            <TextBlock>
-                <TextBlock.Text>
-                    <MultiBinding StringFormat="Items: {0}">
-                        <Binding Path="TotalItemCount" />
-                    </MultiBinding>
-                </TextBlock.Text>
-            </TextBlock>
-        </Border>
-
-        <!-- Data grid -->
-        <DataGrid x:Name="ItemsGrid"
-                  ItemsSource="{Binding Items}"
-                  AutoGenerateColumns="False"
-                  IsReadOnly="True"
-                  CanUserReorderColumns="True"
-                  CanUserResizeColumns="True"
-                  CanUserSortColumns="True"
-                  GridLinesVisibility="Horizontal"
-                  BorderThickness="0">
-            <DataGrid.ContextMenu>
-                <ContextMenu>
-                    <MenuItem Header="Copy Planet" />
-                    <MenuItem Header="Copy Solar System" />
-                    <Separator />
-                    <MenuItem Header="Export to CSV..." />
-                </ContextMenu>
-            </DataGrid.ContextMenu>
-            <DataGrid.Columns>
-                <DataGridTextColumn Header="Planet" Binding="{Binding Colony.PlanetName}" Width="150" />
-                <DataGridTextColumn Header="Planet Type" Binding="{Binding Colony.PlanetTypeName}" Width="100" />
-                <DataGridTextColumn Header="Pin Type" Binding="{Binding TypeName}" Width="200" />
-                <DataGridTextColumn Header="Content" Binding="{Binding ContentTypeName}" Width="150" />
-                <DataGridTextColumn Header="Quantity" Binding="{Binding ContentQuantity}" Width="80" />
-                <DataGridTextColumn Header="State" Binding="{Binding State}" Width="80" />
-                <DataGridTextColumn Header="Expiry" Binding="{Binding ExpiryTime, StringFormat=\{0:yyyy-MM-dd HH:mm\}}" Width="140" />
-                <DataGridTextColumn Header="Solar System" Binding="{Binding Colony.SolarSystem.Name}" Width="120" />
-            </DataGrid.Columns>
-        </DataGrid>
+            <!-- Data view (grid) -->
+            <DataGrid x:Name="ItemsGrid" IsVisible="False"
+                      AutoGenerateColumns="False"
+                      IsReadOnly="True"
+                      CanUserReorderColumns="True"
+                      CanUserResizeColumns="True"
+                      CanUserSortColumns="True"
+                      GridLinesVisibility="Horizontal"
+                      BorderThickness="0">
+                <DataGrid.Columns>
+                    <DataGridTextColumn Header="Planet" Binding="{Binding Colony.PlanetName}" Width="150" />
+                    <DataGridTextColumn Header="Planet Type" Binding="{Binding Colony.PlanetTypeName}" Width="100" />
+                    <DataGridTextColumn Header="Pin Type" Binding="{Binding TypeName}" Width="200" />
+                    <DataGridTextColumn Header="Content" Binding="{Binding ContentTypeName}" Width="150" />
+                    <DataGridTextColumn Header="Quantity" Binding="{Binding ContentQuantity}" Width="80" />
+                    <DataGridTextColumn Header="State" Binding="{Binding State}" Width="80" />
+                    <DataGridTextColumn Header="Expiry" Binding="{Binding ExpiryTime, StringFormat=\{0:yyyy-MM-dd HH:mm\}}" Width="140" />
+                    <DataGridTextColumn Header="Solar System" Binding="{Binding Colony.SolarSystem.Name}" Width="120" />
+                </DataGrid.Columns>
+            </DataGrid>
         </DockPanel>
     </Panel>
 </UserControl>

--- a/src/EveLens.Avalonia/Views/CharacterMonitor/CharacterPlanetaryView.axaml.cs
+++ b/src/EveLens.Avalonia/Views/CharacterMonitor/CharacterPlanetaryView.axaml.cs
@@ -4,17 +4,23 @@
 // Licensed under GPL v2 — see LICENSE for details
 
 using System;
+using System.Linq;
 using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Layout;
+using Avalonia.Media;
 using Avalonia.VisualTree;
+using Avalonia.Interactivity;
 using EveLens.Common.Models;
 using EveLens.Common.ViewModels;
 using EveLens.Common.ViewModels.Lists;
-using Avalonia.Interactivity;
 using EveLens.Common.Constants;
 using EveLens.Common.Enumerations.CCPAPI;
 using EveLens.Common.Events;
 using EveLens.Common.Services;
+using EveLens.Common.Services.Planetary;
+using EveLens.Avalonia.Controls;
+using EveLens.Avalonia.Services;
 
 namespace EveLens.Avalonia.Views.CharacterMonitor
 {
@@ -22,13 +28,17 @@ namespace EveLens.Avalonia.Views.CharacterMonitor
     {
         private IDisposable? _dataUpdatedSub;
         private long _characterId;
-        private PlanetaryListViewModel? _viewModel;
+        private PlanetaryListViewModel? _listViewModel;
+        private PlanetaryDashboardViewModel? _dashboardViewModel;
+        private ColonyFlowCanvas? _flowCanvas;
+        private bool _showDashboard = true;
 
         public CharacterPlanetaryView()
         {
             InitializeComponent();
             LocalizeUI();
         }
+
         private void LocalizeUI()
         {
             EnableTitle.Text = Loc.Get("ListView.EnablePlanetary");
@@ -36,9 +46,7 @@ namespace EveLens.Avalonia.Views.CharacterMonitor
             EnableBtn.Content = Loc.Get("ListView.EnablePlanetaryBtn");
             ScopeTitle.Text = Loc.Get("ListView.ScopeNotAuthorized");
             ScopeSubtext.Text = Loc.Get("ListView.ScopeNotAuthorizedDesc");
-            FilterLabel.Text = Loc.Get("ListView.Filter");
         }
-
 
         protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
         {
@@ -50,7 +58,7 @@ namespace EveLens.Avalonia.Views.CharacterMonitor
         protected override void OnDataContextChanged(EventArgs e)
         {
             base.OnDataContextChanged(e);
-            if (_viewModel != null && DataContext is Character)
+            if ((_dashboardViewModel != null || _listViewModel != null) && DataContext is Character)
                 LoadData();
         }
 
@@ -68,12 +76,12 @@ namespace EveLens.Avalonia.Views.CharacterMonitor
 
             _characterId = character.CharacterID;
 
-            // Check if on-demand endpoint is enabled
             var parentView = this.FindAncestorOfType<CharacterMonitorView>();
             var oc = parentView?.DataContext as ObservableCharacter;
             var prompt = this.FindControl<Border>("EnablePrompt");
             var scopePrompt = this.FindControl<Border>("ScopePrompt");
             var content = this.FindControl<DockPanel>("DataContent");
+
             if (oc != null && !oc.IsEndpointEnabled(ESIAPICharacterMethods.PlanetaryColonies))
             {
                 if (prompt != null) prompt.IsVisible = true;
@@ -91,21 +99,516 @@ namespace EveLens.Avalonia.Views.CharacterMonitor
             if (scopePrompt != null) scopePrompt.IsVisible = false;
             if (content != null) content.IsVisible = true;
 
-            _viewModel ??= new PlanetaryListViewModel();
-            if (_viewModel.Character != character)
-                _viewModel.Character = character;
+            if (_showDashboard)
+                LoadDashboard(character);
             else
-                _viewModel.ForceRefresh();
-            DataContext = _viewModel;
+                LoadDataGrid(character);
+
+            UpdateToggleVisuals();
         }
 
-        protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
+        private void LoadDashboard(Character character)
         {
-            base.OnDetachedFromVisualTree(e);
-            _dataUpdatedSub?.Dispose();
-            _dataUpdatedSub = null;
-            _viewModel?.Dispose();
-            _viewModel = null;
+            _dashboardViewModel ??= new PlanetaryDashboardViewModel();
+            if (_dashboardViewModel.Character != character)
+                _dashboardViewModel.Character = character;
+            else
+                _dashboardViewModel.Refresh();
+
+            DashboardPanel.IsVisible = true;
+            ItemsGrid.IsVisible = false;
+
+            BuildColonyCards();
+            UpdateStatusBar();
+        }
+
+        private void LoadDataGrid(Character character)
+        {
+            _listViewModel ??= new PlanetaryListViewModel();
+            if (_listViewModel.Character != character)
+                _listViewModel.Character = character;
+            else
+                _listViewModel.ForceRefresh();
+
+            DashboardPanel.IsVisible = false;
+            ItemsGrid.IsVisible = true;
+            ItemsGrid.ItemsSource = _listViewModel.GroupedItems?.SelectMany(g => g.Items).ToList();
+            UpdateStatusBar();
+        }
+
+        private void BuildColonyCards()
+        {
+            CardsPanel.Children.Clear();
+
+            if (_dashboardViewModel == null) return;
+
+            // Beta banner
+            CardsPanel.Children.Add(BuildBetaBanner());
+
+            if (_dashboardViewModel.Colonies.Count > 0)
+            {
+                foreach (var card in _dashboardViewModel.Colonies)
+                    CardsPanel.Children.Add(BuildCard(card));
+            }
+            else
+            {
+                CardsPanel.Children.Add(BuildEmptyState());
+            }
+        }
+
+        private static Control BuildBetaBanner()
+        {
+            var panel = new StackPanel
+            {
+                Orientation = Orientation.Horizontal,
+                Spacing = 8,
+                HorizontalAlignment = HorizontalAlignment.Left,
+                Margin = new Thickness(6, 2, 6, 6)
+            };
+
+            var badge = new Border
+            {
+                Background = new SolidColorBrush(Color.FromArgb(180, 230, 180, 30)),
+                CornerRadius = new CornerRadius(4),
+                Padding = new Thickness(8, 2),
+                Child = new TextBlock
+                {
+                    Text = "BETA",
+                    FontSize = FontScaleService.Caption,
+                    FontWeight = FontWeight.Bold,
+                    Foreground = Brushes.Black
+                }
+            };
+
+            var desc = new TextBlock
+            {
+                Text = "Planetary data depends on ESI availability. Economics shown only when extraction data is present.",
+                FontSize = FontScaleService.Caption,
+                Foreground = new SolidColorBrush(Color.FromRgb(230, 180, 30)),
+                VerticalAlignment = VerticalAlignment.Center,
+                FontStyle = FontStyle.Italic
+            };
+
+            panel.Children.Add(badge);
+            panel.Children.Add(desc);
+
+            return new Border
+            {
+                Child = panel,
+                Background = new SolidColorBrush(Color.FromArgb(20, 230, 180, 30)),
+                CornerRadius = new CornerRadius(6),
+                Padding = new Thickness(10, 6),
+                BorderBrush = new SolidColorBrush(Color.FromArgb(60, 230, 180, 30)),
+                BorderThickness = new Thickness(1),
+                HorizontalAlignment = HorizontalAlignment.Stretch,
+                Margin = new Thickness(0, 0, 0, 4)
+            };
+        }
+
+        private Control BuildCard(ColonyCardData card)
+        {
+            var (healthBrush, healthBgBrush, healthBorderBrush) = GetHealthVisuals(card.Health);
+
+            // Security color
+            IBrush secBrush;
+            try { secBrush = new SolidColorBrush(Color.Parse(card.SecurityColor)); }
+            catch { secBrush = Brushes.Gray; }
+
+            var contentPanel = new StackPanel { Spacing = 6 };
+
+            // Row 1: Planet name + sec badge
+            var headerRow = new DockPanel();
+            var secBadge = new Border
+            {
+                Background = secBrush,
+                CornerRadius = new CornerRadius(3),
+                Padding = new Thickness(5, 1),
+                Child = new TextBlock
+                {
+                    Text = card.SecurityDisplay,
+                    FontSize = FontScaleService.Caption,
+                    Foreground = Brushes.White,
+                    FontWeight = FontWeight.Bold
+                },
+                VerticalAlignment = VerticalAlignment.Center,
+                Opacity = 0.9
+            };
+            DockPanel.SetDock(secBadge, Dock.Right);
+            headerRow.Children.Add(secBadge);
+            headerRow.Children.Add(new TextBlock
+            {
+                Text = card.PlanetName,
+                FontSize = FontScaleService.Subheading,
+                FontWeight = FontWeight.SemiBold,
+                Foreground = Application.Current!.FindResource("EveAccentPrimaryBrush") as IBrush ?? Brushes.Gold,
+                TextTrimming = TextTrimming.CharacterEllipsis
+            });
+            contentPanel.Children.Add(headerRow);
+
+            // Row 2: Type + System
+            contentPanel.Children.Add(new TextBlock
+            {
+                Text = $"{card.PlanetTypeName} -- {card.SystemName}",
+                FontSize = FontScaleService.Caption,
+                Foreground = Application.Current!.FindResource("EveTextDisabledBrush") as IBrush ?? Brushes.Gray
+            });
+
+            // Row 3: HERO TIMER — big countdown
+            var timerPanel = new Border
+            {
+                Background = healthBgBrush,
+                CornerRadius = new CornerRadius(6),
+                Padding = new Thickness(10, 8),
+                Margin = new Thickness(0, 2)
+            };
+            var timerContent = new DockPanel();
+            var timerText = new TextBlock
+            {
+                Text = card.TimeRemainingDisplay,
+                FontSize = FontScaleService.Title,
+                FontWeight = FontWeight.Bold,
+                Foreground = healthBrush,
+                VerticalAlignment = VerticalAlignment.Center
+            };
+            var timerLabel = new TextBlock
+            {
+                Text = card.HealthLabel,
+                FontSize = FontScaleService.Caption,
+                Foreground = healthBrush,
+                VerticalAlignment = VerticalAlignment.Center,
+                HorizontalAlignment = HorizontalAlignment.Right,
+                Opacity = 0.8
+            };
+            DockPanel.SetDock(timerLabel, Dock.Right);
+            timerContent.Children.Add(timerLabel);
+            timerContent.Children.Add(timerText);
+            timerPanel.Child = timerContent;
+            contentPanel.Children.Add(timerPanel);
+
+            // Row 4: Extractors + Factories
+            var countsRow = new DockPanel { Margin = new Thickness(0, 2, 0, 0) };
+            var ecuText = new TextBlock
+            {
+                Text = $"{card.ActiveExtractors}/{card.TotalExtractors} extractors",
+                FontSize = FontScaleService.Small,
+                Foreground = card.ActiveExtractors == card.TotalExtractors
+                    ? (Application.Current!.FindResource("EveTextPrimaryBrush") as IBrush ?? Brushes.White)
+                    : (Application.Current!.FindResource("EveWarningYellowBrush") as IBrush ?? Brushes.Orange)
+            };
+            var factoryText = new TextBlock
+            {
+                Text = $"{card.FactoryCount} factories",
+                FontSize = FontScaleService.Small,
+                Foreground = Application.Current!.FindResource("EveTextSecondaryBrush") as IBrush ?? Brushes.LightGray,
+                HorizontalAlignment = HorizontalAlignment.Right
+            };
+            DockPanel.SetDock(factoryText, Dock.Right);
+            countsRow.Children.Add(factoryText);
+            countsRow.Children.Add(ecuText);
+            contentPanel.Children.Add(countsRow);
+
+            // Row 5: Output + Economics (conditional)
+            if (card.HasYieldData)
+            {
+                var econRow = new DockPanel { Margin = new Thickness(0, 2, 0, 0) };
+                var outputLabel = new TextBlock
+                {
+                    Text = $"{card.OutputTierLabel}: {card.OutputName}",
+                    FontSize = FontScaleService.Small,
+                    Foreground = Application.Current!.FindResource("EveTextPrimaryBrush") as IBrush ?? Brushes.White,
+                    TextTrimming = TextTrimming.CharacterEllipsis
+                };
+                var iskLabel = new TextBlock
+                {
+                    Text = FormatIsk(card.NetIskPerDay) + "/day",
+                    FontSize = FontScaleService.Small,
+                    FontWeight = FontWeight.SemiBold,
+                    Foreground = Application.Current!.FindResource("EveSuccessGreenBrush") as IBrush ?? Brushes.LimeGreen,
+                    HorizontalAlignment = HorizontalAlignment.Right
+                };
+                DockPanel.SetDock(iskLabel, Dock.Right);
+                econRow.Children.Add(iskLabel);
+                econRow.Children.Add(outputLabel);
+                contentPanel.Children.Add(econRow);
+            }
+            else if (card.Health != ColonyHealthStatus.NoExtractors)
+            {
+                contentPanel.Children.Add(new TextBlock
+                {
+                    Text = "No yield data from ESI",
+                    FontSize = FontScaleService.Caption,
+                    Foreground = Application.Current!.FindResource("EveTextDisabledBrush") as IBrush ?? Brushes.DarkGray,
+                    FontStyle = FontStyle.Italic,
+                    Margin = new Thickness(0, 2, 0, 0)
+                });
+            }
+
+            // Card border
+            var cardBorder = new Border
+            {
+                Width = 300,
+                MinHeight = 140,
+                Padding = new Thickness(14, 12),
+                CornerRadius = new CornerRadius(8),
+                BorderThickness = new Thickness(1),
+                BorderBrush = healthBorderBrush,
+                Background = Application.Current!.FindResource("EveBackgroundMediumBrush") as IBrush ?? Brushes.DarkSlateGray,
+                Margin = new Thickness(5),
+                Child = contentPanel
+            };
+
+            // Left accent bar
+            var accentBar = new Border
+            {
+                Width = 3,
+                Background = healthBrush,
+                HorizontalAlignment = HorizontalAlignment.Left,
+                CornerRadius = new CornerRadius(8, 0, 0, 8)
+            };
+
+            var cardGrid = new Grid { Width = 300, MinHeight = 140, Margin = new Thickness(5) };
+            cardGrid.Children.Add(cardBorder);
+            cardGrid.Children.Add(accentBar);
+
+            var btn = new Button
+            {
+                Content = cardGrid,
+                Background = Brushes.Transparent,
+                BorderThickness = new Thickness(0),
+                Padding = new Thickness(0),
+                Tag = card.Colony,
+                Cursor = new global::Avalonia.Input.Cursor(global::Avalonia.Input.StandardCursorType.Hand)
+            };
+            btn.Click += OnColonyCardClick;
+
+            return btn;
+        }
+
+        private Control BuildEmptyState()
+        {
+            return new Border
+            {
+                HorizontalAlignment = HorizontalAlignment.Center,
+                VerticalAlignment = VerticalAlignment.Center,
+                Margin = new Thickness(20),
+                Child = new TextBlock
+                {
+                    Text = "No planetary colonies found. Set up extractors in-game to see data here.",
+                    FontSize = FontScaleService.Subheading,
+                    Foreground = Application.Current!.FindResource("EveTextDisabledBrush") as IBrush ?? Brushes.Gray,
+                    TextWrapping = TextWrapping.Wrap,
+                    TextAlignment = TextAlignment.Center
+                }
+            };
+        }
+
+        private void UpdateStatusBar()
+        {
+            if (_showDashboard && _dashboardViewModel != null)
+            {
+                var parts = $"Colonies: {_dashboardViewModel.TotalColonies}";
+                if (_dashboardViewModel.IdleColonies > 0)
+                    parts += $" | {_dashboardViewModel.IdleColonies} idle";
+                if (_dashboardViewModel.ExpiringColonies > 0)
+                    parts += $" | {_dashboardViewModel.ExpiringColonies} expiring soon";
+                if (_dashboardViewModel.HasAnyEconomicsData)
+                    parts += $" | Est. {FormatIsk(_dashboardViewModel.TotalNetIskPerDay)}/day";
+                StatusBar.Text = parts;
+            }
+            else if (_listViewModel != null)
+            {
+                var items = _listViewModel.GroupedItems?.SelectMany(g => g.Items);
+                int count = items?.Count() ?? 0;
+                StatusBar.Text = $"Items: {count}";
+            }
+        }
+
+        private void UpdateToggleVisuals()
+        {
+            if (_showDashboard)
+            {
+                DashboardToggle.Background = Application.Current!.FindResource("EveAccentPrimaryBrush") as IBrush ?? Brushes.Gold;
+                DashboardToggle.Foreground = Brushes.Black;
+                DataToggle.Background = Brushes.Transparent;
+                DataToggle.Foreground = Application.Current!.FindResource("EveTextSecondaryBrush") as IBrush ?? Brushes.Gray;
+            }
+            else
+            {
+                DataToggle.Background = Application.Current!.FindResource("EveAccentPrimaryBrush") as IBrush ?? Brushes.Gold;
+                DataToggle.Foreground = Brushes.Black;
+                DashboardToggle.Background = Brushes.Transparent;
+                DashboardToggle.Foreground = Application.Current!.FindResource("EveTextSecondaryBrush") as IBrush ?? Brushes.Gray;
+            }
+        }
+
+        private static (IBrush fill, IBrush bg, IBrush border) GetHealthVisuals(ColonyHealthStatus health)
+        {
+            return health switch
+            {
+                ColonyHealthStatus.Optimal => (
+                    Brushes.LimeGreen,
+                    new SolidColorBrush(Color.FromArgb(25, 50, 205, 50)),
+                    new SolidColorBrush(Color.FromArgb(50, 50, 205, 50))),
+                ColonyHealthStatus.Expiring => (
+                    Brushes.Orange,
+                    new SolidColorBrush(Color.FromArgb(25, 255, 165, 0)),
+                    new SolidColorBrush(Color.FromArgb(50, 255, 165, 0))),
+                ColonyHealthStatus.Idle => (
+                    Brushes.Red,
+                    new SolidColorBrush(Color.FromArgb(25, 255, 60, 60)),
+                    new SolidColorBrush(Color.FromArgb(50, 255, 60, 60))),
+                _ => (
+                    Brushes.Gray,
+                    new SolidColorBrush(Color.FromArgb(15, 128, 128, 128)),
+                    new SolidColorBrush(Color.FromArgb(40, 128, 128, 128)))
+            };
+        }
+
+        private static string FormatIsk(double isk)
+        {
+            if (Math.Abs(isk) >= 1_000_000_000)
+                return $"{isk / 1_000_000_000:F1}B";
+            if (Math.Abs(isk) >= 1_000_000)
+                return $"{isk / 1_000_000:F1}M";
+            if (Math.Abs(isk) >= 1_000)
+                return $"{isk / 1_000:F1}K";
+            return $"{isk:F0}";
+        }
+
+        // ── Event handlers ──
+
+        private void OnToggleDashboard(object? sender, RoutedEventArgs e)
+        {
+            if (_showDashboard) return;
+            _showDashboard = true;
+            LoadData();
+        }
+
+        private void OnToggleData(object? sender, RoutedEventArgs e)
+        {
+            if (!_showDashboard) return;
+            _showDashboard = false;
+            LoadData();
+        }
+
+        private void OnFilterChanged(object? sender, TextChangedEventArgs e)
+        {
+            string text = FilterBox.Text ?? "";
+            ClearFilterBtn.IsVisible = text.Length > 0;
+
+            if (_showDashboard && _dashboardViewModel != null)
+            {
+                _dashboardViewModel.TextFilter = text;
+                BuildColonyCards();
+                UpdateStatusBar();
+            }
+            else if (_listViewModel != null)
+            {
+                _listViewModel.TextFilter = text;
+                ItemsGrid.ItemsSource = _listViewModel.GroupedItems?.SelectMany(g => g.Items).ToList();
+                UpdateStatusBar();
+            }
+        }
+
+        private void OnClearFilter(object? sender, RoutedEventArgs e)
+        {
+            FilterBox.Text = "";
+        }
+
+        private void OnColonyCardClick(object? sender, RoutedEventArgs e)
+        {
+            if (sender is not Button btn || btn.Tag is not PlanetaryColony colony) return;
+            ShowColonyDetail(colony);
+        }
+
+        private void ShowColonyDetail(PlanetaryColony colony)
+        {
+            _flowCanvas ??= new ColonyFlowCanvas();
+            _flowCanvas.SetColony(colony);
+            _flowCanvas.MinHeight = 300;
+
+            FlowCanvasHost.Content = _flowCanvas;
+            DetailTitle.Text = $"{colony.PlanetName} -- {colony.PlanetTypeName} -- {colony.SolarSystem?.Name ?? "Unknown"}";
+
+            // Stats panel
+            DetailStatsPanel.Children.Clear();
+            var analysis = ProductionChainAnalyzer.Analyze(colony);
+            var (healthBrush, _, _) = GetHealthVisuals(analysis.Health);
+
+            // Timer stat (hero)
+            var timeUntilIdle = analysis.TimeUntilFirstIdle;
+            string timerDisplay = analysis.Health == ColonyHealthStatus.Idle ? "IDLE"
+                : timeUntilIdle <= TimeSpan.Zero ? "Expired"
+                : timeUntilIdle.TotalDays >= 1 ? $"{(int)timeUntilIdle.TotalDays}d {timeUntilIdle.Hours}h"
+                : timeUntilIdle.TotalHours >= 1 ? $"{(int)timeUntilIdle.TotalHours}h {timeUntilIdle.Minutes}m"
+                : $"{timeUntilIdle.Minutes}m";
+
+            DetailStatsPanel.Children.Add(BuildDetailStat("Time Left", timerDisplay, healthBrush));
+            DetailStatsPanel.Children.Add(BuildDetailStat("Status", analysis.Health.ToString(), healthBrush));
+            DetailStatsPanel.Children.Add(BuildDetailStat("Extractors",
+                $"{analysis.ActiveExtractorCount}/{analysis.TotalExtractorCount}",
+                analysis.ActiveExtractorCount == analysis.TotalExtractorCount ? Brushes.LimeGreen : Brushes.Orange));
+            DetailStatsPanel.Children.Add(BuildDetailStat("Factories", analysis.FactoryCount.ToString(), null));
+
+            // Conditional economics
+            if (analysis.HasYieldData)
+            {
+                int cceLevel = 0;
+                if (_dashboardViewModel?.Character != null)
+                {
+                    var skill = Common.Data.StaticSkills.GetSkillByName("Customs Code Expertise");
+                    if (skill != null) cceLevel = (int)_dashboardViewModel.Character.GetSkillLevel(skill);
+                }
+                var econ = new ColonyEconomicsService(cceLevel).Calculate(analysis);
+
+                DetailStatsPanel.Children.Add(BuildDetailStat("Gross/day", FormatIsk(econ.GrossIskPerDay), Brushes.LimeGreen));
+                DetailStatsPanel.Children.Add(BuildDetailStat("Tax/day", $"-{FormatIsk(econ.TaxCostPerDay)}", Brushes.Orange));
+                DetailStatsPanel.Children.Add(BuildDetailStat("Net/day", FormatIsk(econ.NetIskPerDay), Brushes.LimeGreen));
+                DetailStatsPanel.Children.Add(BuildDetailStat("Tax Rate", $"{econ.TaxRate * 100:F1}%", null));
+            }
+            else
+            {
+                DetailStatsPanel.Children.Add(BuildDetailStat("Economics", "No data", Brushes.Gray));
+            }
+
+            // Switch to detail view
+            DashboardPanel.IsVisible = false;
+            DetailPanel.IsVisible = true;
+        }
+
+        private void OnBackToCards(object? sender, RoutedEventArgs e)
+        {
+            DetailPanel.IsVisible = false;
+            DashboardPanel.IsVisible = true;
+            _flowCanvas?.Clear();
+        }
+
+        private static Border BuildDetailStat(string label, string value, IBrush? valueBrush)
+        {
+            var panel = new StackPanel { Spacing = 2, HorizontalAlignment = HorizontalAlignment.Center };
+            panel.Children.Add(new TextBlock
+            {
+                Text = value,
+                FontSize = FontScaleService.Body,
+                FontWeight = FontWeight.Bold,
+                Foreground = valueBrush ?? (Application.Current!.FindResource("EveTextPrimaryBrush") as IBrush ?? Brushes.White),
+                HorizontalAlignment = HorizontalAlignment.Center
+            });
+            panel.Children.Add(new TextBlock
+            {
+                Text = label,
+                FontSize = FontScaleService.Caption,
+                Foreground = Application.Current!.FindResource("EveTextDisabledBrush") as IBrush ?? Brushes.Gray,
+                HorizontalAlignment = HorizontalAlignment.Center
+            });
+            return new Border
+            {
+                Padding = new Thickness(12, 6),
+                CornerRadius = new CornerRadius(6),
+                Background = Application.Current!.FindResource("EveBackgroundDarkBrush") as IBrush ?? Brushes.Black,
+                Margin = new Thickness(4),
+                Child = panel
+            };
         }
 
         private void OnEnableEndpoint(object? sender, RoutedEventArgs e)
@@ -120,6 +623,17 @@ namespace EveLens.Avalonia.Views.CharacterMonitor
         {
             if (evt.Character?.CharacterID == _characterId)
                 global::Avalonia.Threading.Dispatcher.UIThread.Post(LoadData);
+        }
+
+        protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
+        {
+            base.OnDetachedFromVisualTree(e);
+            _dataUpdatedSub?.Dispose();
+            _dataUpdatedSub = null;
+            _dashboardViewModel?.Dispose();
+            _dashboardViewModel = null;
+            _listViewModel?.Dispose();
+            _listViewModel = null;
         }
     }
 }

--- a/src/EveLens.Avalonia/Views/CharacterMonitor/CharacterPlanetaryView.axaml.cs
+++ b/src/EveLens.Avalonia/Views/CharacterMonitor/CharacterPlanetaryView.axaml.cs
@@ -11,6 +11,7 @@ using Avalonia.Layout;
 using Avalonia.Media;
 using Avalonia.VisualTree;
 using Avalonia.Interactivity;
+using EveLens.Common.Helpers;
 using EveLens.Common.Models;
 using EveLens.Common.ViewModels;
 using EveLens.Common.ViewModels.Lists;
@@ -464,16 +465,7 @@ namespace EveLens.Avalonia.Views.CharacterMonitor
             };
         }
 
-        private static string FormatIsk(double isk)
-        {
-            if (Math.Abs(isk) >= 1_000_000_000)
-                return $"{isk / 1_000_000_000:F1}B";
-            if (Math.Abs(isk) >= 1_000_000)
-                return $"{isk / 1_000_000:F1}M";
-            if (Math.Abs(isk) >= 1_000)
-                return $"{isk / 1_000:F1}K";
-            return $"{isk:F0}";
-        }
+        private static string FormatIsk(double isk) => FormattingHelper.FormatIsk(isk);
 
         // ── Event handlers ──
 

--- a/src/EveLens.Avalonia/Views/Dialogs/PlanetaryDashboardWindow.axaml
+++ b/src/EveLens.Avalonia/Views/Dialogs/PlanetaryDashboardWindow.axaml
@@ -1,0 +1,62 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        x:Class="EveLens.Avalonia.Views.Dialogs.PlanetaryDashboardWindow"
+        Title="Planetary Dashboard (Beta)"
+        Width="1100" Height="700"
+        MinWidth="850" MinHeight="500"
+        WindowStartupLocation="CenterOwner"
+        Background="{DynamicResource EveBackgroundDarkBrush}">
+
+    <DockPanel>
+        <!-- Status bar -->
+        <Border DockPanel.Dock="Bottom" Padding="10,5"
+                Background="{DynamicResource EveBackgroundMediumBrush}"
+                BorderThickness="0,1,0,0" BorderBrush="{DynamicResource EveBackgroundDarkBrush}">
+            <TextBlock x:Name="StatusBar" FontSize="{DynamicResource EveFontBody}"
+                       Foreground="{DynamicResource EveTextSecondaryBrush}" />
+        </Border>
+
+        <!-- Top: Title + summary stats -->
+        <Border DockPanel.Dock="Top" Padding="16,12"
+                Background="{DynamicResource EveBackgroundMediumBrush}">
+            <DockPanel>
+                <TextBlock Text="Planetary Dashboard" FontSize="{DynamicResource EveFontTitle}"
+                           FontWeight="Bold" Foreground="{DynamicResource EveAccentPrimaryBrush}"
+                           VerticalAlignment="Center" DockPanel.Dock="Left" />
+                <StackPanel x:Name="SummaryCards" Orientation="Horizontal" Spacing="12"
+                            HorizontalAlignment="Right" VerticalAlignment="Center" />
+            </DockPanel>
+        </Border>
+
+        <!-- Toolbar -->
+        <Border DockPanel.Dock="Top" Padding="10,6"
+                Background="{DynamicResource EveBackgroundMediumBrush}"
+                BorderThickness="0,0,0,1" BorderBrush="{DynamicResource EveBackgroundDarkBrush}">
+            <DockPanel>
+                <StackPanel DockPanel.Dock="Left" Orientation="Horizontal" Spacing="8">
+                    <Button x:Name="RefreshBtn" Content="Refresh" FontSize="{DynamicResource EveFontBody}"
+                            Padding="10,4" CornerRadius="12" Click="OnRefresh" />
+                    <Button x:Name="AttentionOnlyBtn" Content="Needs Attention"
+                            FontSize="{DynamicResource EveFontBody}"
+                            Padding="10,4" CornerRadius="12" Click="OnToggleAttentionOnly" />
+                </StackPanel>
+
+                <!-- Search -->
+                <Border DockPanel.Dock="Right" CornerRadius="14" Padding="8,3"
+                        Background="{DynamicResource EveBackgroundDarkBrush}" MinWidth="180">
+                    <TextBox x:Name="FilterBox" Watermark="Search characters..."
+                             Background="Transparent" BorderThickness="0"
+                             FontSize="{DynamicResource EveFontBody}"
+                             TextChanged="OnFilterChanged" />
+                </Border>
+
+                <Panel /> <!-- spacer -->
+            </DockPanel>
+        </Border>
+
+        <!-- Alert timeline + character table -->
+        <ScrollViewer>
+            <StackPanel x:Name="ContentPanel" Margin="8,4" Spacing="8" />
+        </ScrollViewer>
+    </DockPanel>
+</Window>

--- a/src/EveLens.Avalonia/Views/Dialogs/PlanetaryDashboardWindow.axaml.cs
+++ b/src/EveLens.Avalonia/Views/Dialogs/PlanetaryDashboardWindow.axaml.cs
@@ -1,0 +1,505 @@
+// EveLens — Character Intelligence for EVE Online
+// Copyright © 2006-2021 EVEMon Development Team, © 2025-2026 Alia Collins
+// Built with Claude Code (Anthropic)
+// Licensed under GPL v2 — see LICENSE for details
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+using Avalonia.Layout;
+using Avalonia.Media;
+using EveLens.Avalonia.Services;
+using EveLens.Common.Models;
+using EveLens.Common.Services;
+using EveLens.Common.Services.Planetary;
+using EveLens.Common.ViewModels;
+
+namespace EveLens.Avalonia.Views.Dialogs
+{
+    public partial class PlanetaryDashboardWindow : Window
+    {
+        private readonly PlanetaryOverviewViewModel _vm = new();
+        private bool _attentionOnly;
+        private string _filter = "";
+
+        public PlanetaryDashboardWindow()
+        {
+            InitializeComponent();
+            _vm.Refresh();
+            RebuildUI();
+        }
+
+        private void RebuildUI()
+        {
+            BuildSummaryCards();
+            BuildContent();
+            UpdateStatus();
+        }
+
+        private void BuildSummaryCards()
+        {
+            SummaryCards.Children.Clear();
+
+            SummaryCards.Children.Add(BuildStat("Characters", _vm.TotalCharacters.ToString(), null));
+            SummaryCards.Children.Add(BuildStat("Colonies", _vm.TotalColonies.ToString(), null));
+
+            var activeBrush = _vm.IdleExtractors > 0 ? Brushes.Orange : Brushes.LimeGreen;
+            SummaryCards.Children.Add(BuildStat("Active ECU",
+                $"{_vm.ActiveExtractors}/{_vm.ActiveExtractors + _vm.IdleExtractors}", activeBrush));
+
+            if (_vm.ExpiringCount > 0)
+                SummaryCards.Children.Add(BuildStat("Expiring", _vm.ExpiringCount.ToString(), Brushes.Orange));
+
+            if (_vm.CharactersNeedingAttention > 0)
+                SummaryCards.Children.Add(BuildStat("Need Attention",
+                    _vm.CharactersNeedingAttention.ToString(), Brushes.Red));
+
+            if (_vm.HasAnyEconomicsData)
+                SummaryCards.Children.Add(BuildStat("Est. Net/day", FormatIsk(_vm.TotalNetIskPerDay), Brushes.LimeGreen));
+        }
+
+        private static Border BuildStat(string label, string value, IBrush? valueBrush)
+        {
+            var panel = new StackPanel { Spacing = 1, HorizontalAlignment = HorizontalAlignment.Center };
+            panel.Children.Add(new TextBlock
+            {
+                Text = value,
+                FontSize = FontScaleService.Subheading,
+                FontWeight = FontWeight.Bold,
+                Foreground = valueBrush ?? (Application.Current!.FindResource("EveTextPrimaryBrush") as IBrush ?? Brushes.White),
+                HorizontalAlignment = HorizontalAlignment.Center
+            });
+            panel.Children.Add(new TextBlock
+            {
+                Text = label,
+                FontSize = FontScaleService.Caption,
+                Foreground = Application.Current!.FindResource("EveTextDisabledBrush") as IBrush ?? Brushes.Gray,
+                HorizontalAlignment = HorizontalAlignment.Center
+            });
+
+            return new Border
+            {
+                Padding = new Thickness(12, 6),
+                CornerRadius = new CornerRadius(6),
+                Background = Application.Current!.FindResource("EveBackgroundDarkBrush") as IBrush ?? Brushes.Black,
+                Child = panel
+            };
+        }
+
+        private void BuildContent()
+        {
+            ContentPanel.Children.Clear();
+
+            // Beta banner
+            ContentPanel.Children.Add(BuildBetaBanner());
+
+            var entries = _vm.Entries.AsEnumerable();
+
+            if (_attentionOnly)
+                entries = entries.Where(e => e.NeedsAttention);
+
+            if (!string.IsNullOrWhiteSpace(_filter))
+                entries = entries.Where(e => e.CharacterName.Contains(_filter, StringComparison.OrdinalIgnoreCase));
+
+            var entryList = entries.ToList();
+
+            // Build alert timeline section if there are expiring/idle extractors
+            var alerts = BuildAlertTimeline(entryList);
+            if (alerts != null)
+                ContentPanel.Children.Add(alerts);
+
+            // Character rows
+            ContentPanel.Children.Add(BuildSectionHeader("All Characters"));
+            ContentPanel.Children.Add(BuildHeaderRow());
+
+            foreach (var entry in entryList)
+                ContentPanel.Children.Add(BuildCharacterRow(entry));
+
+            if (entryList.Count == 0)
+                ContentPanel.Children.Add(BuildEmptyMessage());
+        }
+
+        private Control? BuildAlertTimeline(List<PlanetaryCharacterEntry> entries)
+        {
+            var alertItems = new List<(string charName, string planetName, TimeSpan timeLeft, ColonyHealthStatus health)>();
+
+            foreach (var entry in entries)
+            {
+                if (entry.Character is not CCPCharacter ccp) continue;
+
+                foreach (var colony in ccp.PlanetaryColonies)
+                {
+                    var analysis = ProductionChainAnalyzer.Analyze(colony);
+                    if (analysis.Health == ColonyHealthStatus.Idle)
+                    {
+                        alertItems.Add((entry.CharacterName, colony.PlanetName, TimeSpan.Zero, ColonyHealthStatus.Idle));
+                    }
+                    else if (analysis.Health == ColonyHealthStatus.Expiring)
+                    {
+                        alertItems.Add((entry.CharacterName, colony.PlanetName, analysis.TimeUntilFirstIdle, ColonyHealthStatus.Expiring));
+                    }
+                }
+            }
+
+            if (alertItems.Count == 0) return null;
+
+            // Sort: idle first, then by time ascending
+            alertItems.Sort((a, b) =>
+            {
+                if (a.health == ColonyHealthStatus.Idle && b.health != ColonyHealthStatus.Idle) return -1;
+                if (b.health == ColonyHealthStatus.Idle && a.health != ColonyHealthStatus.Idle) return 1;
+                return a.timeLeft.CompareTo(b.timeLeft);
+            });
+
+            var section = new StackPanel { Spacing = 3 };
+            section.Children.Add(BuildSectionHeader("Alerts"));
+
+            foreach (var alert in alertItems.Take(12))
+            {
+                var (brush, bgBrush) = alert.health == ColonyHealthStatus.Idle
+                    ? (Brushes.Red, new SolidColorBrush(Color.FromArgb(20, 255, 60, 60)))
+                    : (Brushes.Orange, new SolidColorBrush(Color.FromArgb(15, 255, 165, 0)));
+
+                string timeText = alert.health == ColonyHealthStatus.Idle ? "IDLE"
+                    : alert.timeLeft.TotalDays >= 1 ? $"{(int)alert.timeLeft.TotalDays}d {alert.timeLeft.Hours}h"
+                    : alert.timeLeft.TotalHours >= 1 ? $"{(int)alert.timeLeft.TotalHours}h {alert.timeLeft.Minutes}m"
+                    : $"{alert.timeLeft.Minutes}m";
+
+                var row = new Border
+                {
+                    Background = bgBrush,
+                    CornerRadius = new CornerRadius(4),
+                    Padding = new Thickness(12, 6),
+                    Margin = new Thickness(0, 1)
+                };
+
+                var grid = new Grid { ColumnDefinitions = new ColumnDefinitions("Auto,*,Auto") };
+
+                var timeBlock = new TextBlock
+                {
+                    Text = timeText,
+                    FontSize = FontScaleService.Body,
+                    FontWeight = FontWeight.Bold,
+                    Foreground = brush,
+                    VerticalAlignment = VerticalAlignment.Center,
+                    MinWidth = 70
+                };
+                Grid.SetColumn(timeBlock, 0);
+                grid.Children.Add(timeBlock);
+
+                var descBlock = new TextBlock
+                {
+                    Text = $"{alert.charName} -- {alert.planetName}",
+                    FontSize = FontScaleService.Body,
+                    Foreground = Application.Current!.FindResource("EveTextPrimaryBrush") as IBrush ?? Brushes.White,
+                    VerticalAlignment = VerticalAlignment.Center,
+                    Margin = new Thickness(12, 0, 0, 0)
+                };
+                Grid.SetColumn(descBlock, 1);
+                grid.Children.Add(descBlock);
+
+                var statusBlock = new TextBlock
+                {
+                    Text = alert.health == ColonyHealthStatus.Idle ? "Needs restart" : "Expiring soon",
+                    FontSize = FontScaleService.Caption,
+                    Foreground = brush,
+                    VerticalAlignment = VerticalAlignment.Center,
+                    Opacity = 0.8
+                };
+                Grid.SetColumn(statusBlock, 2);
+                grid.Children.Add(statusBlock);
+
+                row.Child = grid;
+                section.Children.Add(row);
+            }
+
+            if (alertItems.Count > 12)
+            {
+                section.Children.Add(new TextBlock
+                {
+                    Text = $"+ {alertItems.Count - 12} more...",
+                    FontSize = FontScaleService.Caption,
+                    Foreground = Application.Current!.FindResource("EveTextDisabledBrush") as IBrush ?? Brushes.Gray,
+                    Margin = new Thickness(12, 4, 0, 0)
+                });
+            }
+
+            return new Border
+            {
+                Child = section,
+                Background = Application.Current!.FindResource("EveBackgroundMediumBrush") as IBrush ?? Brushes.DarkSlateGray,
+                CornerRadius = new CornerRadius(6),
+                Padding = new Thickness(10, 8),
+                Margin = new Thickness(0, 0, 0, 8)
+            };
+        }
+
+        private static Control BuildBetaBanner()
+        {
+            var panel = new StackPanel
+            {
+                Orientation = Orientation.Horizontal,
+                Spacing = 8,
+                HorizontalAlignment = HorizontalAlignment.Left
+            };
+
+            var badge = new Border
+            {
+                Background = new SolidColorBrush(Color.FromArgb(180, 230, 180, 30)),
+                CornerRadius = new CornerRadius(4),
+                Padding = new Thickness(8, 2),
+                Child = new TextBlock
+                {
+                    Text = "BETA",
+                    FontSize = FontScaleService.Caption,
+                    FontWeight = FontWeight.Bold,
+                    Foreground = Brushes.Black
+                }
+            };
+
+            var desc = new TextBlock
+            {
+                Text = "PI dashboard is in beta. Economics require ESI extraction data which may not be available for all colonies.",
+                FontSize = FontScaleService.Caption,
+                Foreground = new SolidColorBrush(Color.FromRgb(230, 180, 30)),
+                VerticalAlignment = VerticalAlignment.Center,
+                FontStyle = FontStyle.Italic
+            };
+
+            panel.Children.Add(badge);
+            panel.Children.Add(desc);
+
+            return new Border
+            {
+                Child = panel,
+                Background = new SolidColorBrush(Color.FromArgb(20, 230, 180, 30)),
+                CornerRadius = new CornerRadius(6),
+                Padding = new Thickness(10, 6),
+                BorderBrush = new SolidColorBrush(Color.FromArgb(60, 230, 180, 30)),
+                BorderThickness = new Thickness(1),
+                HorizontalAlignment = HorizontalAlignment.Stretch
+            };
+        }
+
+        private static TextBlock BuildSectionHeader(string text) => new TextBlock
+        {
+            Text = text,
+            FontSize = FontScaleService.Subheading,
+            FontWeight = FontWeight.SemiBold,
+            Foreground = Application.Current!.FindResource("EveAccentPrimaryBrush") as IBrush ?? Brushes.Gold,
+            Margin = new Thickness(4, 8, 0, 4)
+        };
+
+        private TextBlock BuildEmptyMessage() => new TextBlock
+        {
+            Text = _attentionOnly
+                ? "No characters need attention right now."
+                : "No characters with planetary colonies found.",
+            FontSize = FontScaleService.Body,
+            Foreground = Application.Current!.FindResource("EveTextDisabledBrush") as IBrush ?? Brushes.Gray,
+            Margin = new Thickness(20),
+            HorizontalAlignment = HorizontalAlignment.Center
+        };
+
+        private static Grid BuildHeaderRow()
+        {
+            var grid = new Grid
+            {
+                ColumnDefinitions = new ColumnDefinitions("*,60,80,90,90"),
+                Margin = new Thickness(4, 2),
+            };
+
+            var headers = new[] { "Character", "Colonies", "ECU", "Next Idle", "Status" };
+            for (int i = 0; i < headers.Length; i++)
+            {
+                var tb = new TextBlock
+                {
+                    Text = headers[i],
+                    FontSize = FontScaleService.Small,
+                    FontWeight = FontWeight.SemiBold,
+                    Foreground = Application.Current!.FindResource("EveTextSecondaryBrush") as IBrush ?? Brushes.Gray,
+                    VerticalAlignment = VerticalAlignment.Center,
+                    Margin = new Thickness(4, 0)
+                };
+                Grid.SetColumn(tb, i);
+                grid.Children.Add(tb);
+            }
+
+            return grid;
+        }
+
+        private Border BuildCharacterRow(PlanetaryCharacterEntry entry)
+        {
+            var grid = new Grid
+            {
+                ColumnDefinitions = new ColumnDefinitions("*,60,80,90,90"),
+                MinHeight = 36,
+            };
+
+            // Name
+            var nameBlock = new TextBlock
+            {
+                Text = entry.CharacterName,
+                FontSize = FontScaleService.Body,
+                FontWeight = FontWeight.SemiBold,
+                Foreground = Application.Current!.FindResource("EveAccentPrimaryBrush") as IBrush ?? Brushes.Gold,
+                VerticalAlignment = VerticalAlignment.Center,
+                Margin = new Thickness(4, 0)
+            };
+            Grid.SetColumn(nameBlock, 0);
+            grid.Children.Add(nameBlock);
+
+            // Colonies
+            AddCell(grid, 1, entry.ColonyCount.ToString());
+
+            // ECU (active/total)
+            var ecuBrush = entry.IdleExtractorCount > 0
+                ? (Application.Current!.FindResource("EveWarningYellowBrush") as IBrush ?? Brushes.Orange)
+                : (Application.Current!.FindResource("EveTextPrimaryBrush") as IBrush ?? Brushes.White);
+            AddCell(grid, 2, $"{entry.ActiveExtractorCount}/{entry.TotalExtractorCount}", ecuBrush);
+
+            // Time until idle
+            var timeBrush = entry.WorstHealth == ColonyHealthStatus.Idle ? Brushes.Red
+                : entry.WorstHealth == ColonyHealthStatus.Expiring ? Brushes.Orange
+                : (Application.Current!.FindResource("EveTextSecondaryBrush") as IBrush ?? Brushes.Gray);
+            AddCell(grid, 3, entry.TimeDisplay, timeBrush);
+
+            // Health status
+            var healthBrush = GetHealthBrush(entry.WorstHealth);
+            AddCell(grid, 4, entry.HealthDisplay, healthBrush);
+
+            // Row container
+            var rowBorder = new Border
+            {
+                Child = grid,
+                Padding = new Thickness(8, 4),
+                CornerRadius = new CornerRadius(4),
+                Margin = new Thickness(0, 1),
+                Background = entry.NeedsAttention
+                    ? new SolidColorBrush(Color.FromArgb(15, 255, 80, 80))
+                    : Brushes.Transparent,
+                Cursor = new Cursor(StandardCursorType.Hand)
+            };
+
+            var character = entry.Character;
+            rowBorder.PointerPressed += (_, _) => NavigateToCharacterPlanetary(character);
+
+            if (entry.NeedsAttention)
+            {
+                var outerGrid = new Grid();
+                outerGrid.Children.Add(rowBorder);
+                outerGrid.Children.Add(new Border
+                {
+                    Width = 3,
+                    Background = entry.WorstHealth == ColonyHealthStatus.Idle ? Brushes.Red : Brushes.Orange,
+                    HorizontalAlignment = HorizontalAlignment.Left,
+                    CornerRadius = new CornerRadius(3, 0, 0, 3)
+                });
+                return new Border { Child = outerGrid, Margin = new Thickness(0, 1) };
+            }
+
+            return rowBorder;
+        }
+
+        private static void AddCell(Grid grid, int col, string text, IBrush? foreground = null)
+        {
+            var tb = new TextBlock
+            {
+                Text = text,
+                FontSize = FontScaleService.Body,
+                Foreground = foreground ?? (Application.Current!.FindResource("EveTextPrimaryBrush") as IBrush ?? Brushes.White),
+                VerticalAlignment = VerticalAlignment.Center,
+                Margin = new Thickness(4, 0)
+            };
+            Grid.SetColumn(tb, col);
+            grid.Children.Add(tb);
+        }
+
+        private static IBrush GetHealthBrush(ColonyHealthStatus health) => health switch
+        {
+            ColonyHealthStatus.Optimal => Brushes.LimeGreen,
+            ColonyHealthStatus.Expiring => Brushes.Orange,
+            ColonyHealthStatus.Idle => Brushes.Red,
+            _ => Brushes.Gray
+        };
+
+        private void UpdateStatus()
+        {
+            var total = _vm.TotalCharacters;
+            var showing = _attentionOnly ? _vm.Entries.Count(e => e.NeedsAttention) : _vm.Entries.Count;
+            StatusBar.Text = $"Showing {showing} of {total} characters | " +
+                             $"{_vm.TotalColonies} colonies, {_vm.ActiveExtractors + _vm.IdleExtractors} extractors";
+        }
+
+        private static string FormatIsk(double isk)
+        {
+            if (Math.Abs(isk) >= 1_000_000_000)
+                return $"{isk / 1_000_000_000:F1}B";
+            if (Math.Abs(isk) >= 1_000_000)
+                return $"{isk / 1_000_000:F1}M";
+            if (Math.Abs(isk) >= 1_000)
+                return $"{isk / 1_000:F1}K";
+            return $"{isk:F0}";
+        }
+
+        // ── Event handlers ──
+
+        private void OnRefresh(object? sender, RoutedEventArgs e)
+        {
+            _vm.Refresh();
+            RebuildUI();
+        }
+
+        private void OnToggleAttentionOnly(object? sender, RoutedEventArgs e)
+        {
+            _attentionOnly = !_attentionOnly;
+            AttentionOnlyBtn.Background = _attentionOnly
+                ? (Application.Current!.FindResource("EveAccentPrimaryBrush") as IBrush ?? Brushes.Gold)
+                : Brushes.Transparent;
+            AttentionOnlyBtn.Foreground = _attentionOnly
+                ? Brushes.Black
+                : (Application.Current!.FindResource("EveTextSecondaryBrush") as IBrush ?? Brushes.Gray);
+            BuildContent();
+            UpdateStatus();
+        }
+
+        private void OnFilterChanged(object? sender, TextChangedEventArgs e)
+        {
+            _filter = FilterBox.Text ?? "";
+            BuildContent();
+            UpdateStatus();
+        }
+
+        private void NavigateToCharacterPlanetary(Character character)
+        {
+            if (Owner is not MainWindow mainWindow) return;
+
+            Close();
+
+            mainWindow.SelectCharacter(character);
+
+            global::Avalonia.Threading.Dispatcher.UIThread.Post(() =>
+            {
+                var mainContent = mainWindow.FindControl<ContentControl>("MainContent");
+                if (mainContent?.Content is CharacterMonitor.CharacterMonitorView monitorView)
+                {
+                    var tabs = monitorView.FindControl<TabControl>("SubTabs");
+                    if (tabs == null) return;
+
+                    for (int i = 0; i < tabs.Items.Count; i++)
+                    {
+                        if (tabs.Items[i] is TabItem tab && tab.Name == "TabPI")
+                        {
+                            tabs.SelectedIndex = i;
+                            break;
+                        }
+                    }
+                }
+            }, global::Avalonia.Threading.DispatcherPriority.Background);
+        }
+    }
+}

--- a/src/EveLens.Avalonia/Views/Dialogs/PlanetaryDashboardWindow.axaml.cs
+++ b/src/EveLens.Avalonia/Views/Dialogs/PlanetaryDashboardWindow.axaml.cs
@@ -13,6 +13,7 @@ using Avalonia.Interactivity;
 using Avalonia.Layout;
 using Avalonia.Media;
 using EveLens.Avalonia.Services;
+using EveLens.Common.Helpers;
 using EveLens.Common.Models;
 using EveLens.Common.Services;
 using EveLens.Common.Services.Planetary;
@@ -435,16 +436,7 @@ namespace EveLens.Avalonia.Views.Dialogs
                              $"{_vm.TotalColonies} colonies, {_vm.ActiveExtractors + _vm.IdleExtractors} extractors";
         }
 
-        private static string FormatIsk(double isk)
-        {
-            if (Math.Abs(isk) >= 1_000_000_000)
-                return $"{isk / 1_000_000_000:F1}B";
-            if (Math.Abs(isk) >= 1_000_000)
-                return $"{isk / 1_000_000:F1}M";
-            if (Math.Abs(isk) >= 1_000)
-                return $"{isk / 1_000:F1}K";
-            return $"{isk:F0}";
-        }
+        private static string FormatIsk(double isk) => FormattingHelper.FormatIsk(isk);
 
         // ── Event handlers ──
 

--- a/src/EveLens.Avalonia/Views/Dialogs/RemapAttributeDialog.axaml.cs
+++ b/src/EveLens.Avalonia/Views/Dialogs/RemapAttributeDialog.axaml.cs
@@ -30,8 +30,8 @@ namespace EveLens.Avalonia.Views.Dialogs
 
         private static readonly EveAttribute[] AllAttrs =
         {
-            EveAttribute.Intelligence, EveAttribute.Perception,
-            EveAttribute.Charisma, EveAttribute.Willpower, EveAttribute.Memory
+            EveAttribute.Perception, EveAttribute.Memory,
+            EveAttribute.Willpower, EveAttribute.Intelligence, EveAttribute.Charisma
         };
 
         private static readonly IBrush GoldBrush = new SolidColorBrush(Color.Parse("#FFE6A817"));

--- a/src/EveLens.Avalonia/Views/MainWindow.axaml
+++ b/src/EveLens.Avalonia/Views/MainWindow.axaml
@@ -34,6 +34,7 @@
             <MenuItem x:Name="ToolsMenu" Header="_Tools">
                 <MenuItem x:Name="CharCompMenuItem" Header="_Character Comparison" />
                 <MenuItem x:Name="SkillFarmMenuItem" Header="Skill _Farm Dashboard" />
+                <MenuItem x:Name="PlanetaryDashMenuItem" Header="_Planetary Dashboard" />
                 <MenuItem x:Name="GlobalPlanMenuItem" Header="_Doctrine Designer" InputGesture="Ctrl+G" />
                 <MenuItem x:Name="SkillConstellationMenuItem" Header="Skill _Visualization" />
                 <Separator />
@@ -128,93 +129,104 @@
                     </Panel>
                 </Button>
 
-                <!-- Notification bell with flyout -->
-                <Button x:Name="NotificationBellBtn" DockPanel.Dock="Right"
-                        Background="Transparent" BorderThickness="0"
-                        Padding="8,0" VerticalAlignment="Center"
-                        ClipToBounds="False"
-                        Cursor="Hand" ToolTip.Tip="Activity Log">
-                    <Button.Flyout>
-                        <Flyout Placement="TopEdgeAlignedRight">
-                            <Border Background="{StaticResource EveBackgroundMediumBrush}"
-                                    BorderBrush="{StaticResource EveBorderBrush}"
-                                    BorderThickness="1" CornerRadius="6"
-                                    Padding="0" MinWidth="360" MaxHeight="480">
-                                <DockPanel>
-                                    <!-- Header -->
-                                    <Border DockPanel.Dock="Top" Padding="12,8"
-                                            BorderBrush="{StaticResource EveBorderBrush}" BorderThickness="0,0,0,1">
-                                        <DockPanel>
-                                            <TextBlock Text="Activity Log" FontSize="{DynamicResource EveFontSubheading}" FontWeight="SemiBold"
-                                                       Foreground="{StaticResource EveAccentPrimaryBrush}" />
-                                            <StackPanel DockPanel.Dock="Right" Orientation="Horizontal"
-                                                        HorizontalAlignment="Right" Spacing="6">
-                                                <Button x:Name="MarkReadBtn" Content="Mark Read"
-                                                        FontSize="{DynamicResource EveFontSmall}" Padding="8,2" CornerRadius="10"
-                                                        Background="Transparent"
-                                                        Foreground="{StaticResource EveTextSecondaryBrush}" />
-                                                <Button x:Name="ClearAllBtn" Content="Clear"
-                                                        FontSize="{DynamicResource EveFontSmall}" Padding="8,2" CornerRadius="10"
-                                                        Background="Transparent"
-                                                        Foreground="{StaticResource EveTextSecondaryBrush}" />
-                                            </StackPanel>
-                                        </DockPanel>
-                                    </Border>
-                                    <!-- Empty state -->
-                                    <TextBlock x:Name="EmptyActivityText"
-                                               Text="No recent activity"
-                                               FontSize="{DynamicResource EveFontBody}" Foreground="{StaticResource EveTextDisabledBrush}"
-                                               HorizontalAlignment="Center" VerticalAlignment="Center"
-                                               Margin="0,40" IsVisible="False" />
-                                    <!-- Activity list -->
-                                    <ScrollViewer VerticalScrollBarVisibility="Auto">
-                                        <ItemsControl x:Name="ActivityItems">
-                                            <ItemsControl.ItemTemplate>
-                                                <DataTemplate>
-                                                    <Border Padding="12,6"
-                                                            BorderBrush="{StaticResource EveBorderBrush}"
-                                                            BorderThickness="0,0,0,1">
-                                                        <Grid ColumnDefinitions="*,Auto">
-                                                            <StackPanel Spacing="2">
-                                                                <TextBlock Text="{Binding Description}" FontSize="{DynamicResource EveFontBody}"
-                                                                           Foreground="{Binding DescriptionBrush}"
-                                                                           TextTrimming="CharacterEllipsis"
-                                                                           ToolTip.Tip="{Binding Description}" />
-                                                                <StackPanel Orientation="Horizontal" Spacing="8">
-                                                                    <TextBlock Text="{Binding CharacterName}" FontSize="{DynamicResource EveFontSmall}"
-                                                                               Foreground="{StaticResource EveAccentPrimaryBrush}"
-                                                                               IsVisible="{Binding HasCharacter}" />
-                                                                    <TextBlock Text="{Binding CategoryDisplay}" FontSize="{DynamicResource EveFontSmall}"
-                                                                               Foreground="{StaticResource EveTextDisabledBrush}" />
-                                                                </StackPanel>
-                                                            </StackPanel>
-                                                            <TextBlock Grid.Column="1" Text="{Binding TimeAgo}" FontSize="{DynamicResource EveFontSmall}"
-                                                                       Foreground="{StaticResource EveTextDisabledBrush}"
-                                                                       VerticalAlignment="Top" Margin="8,0,0,0" />
-                                                        </Grid>
-                                                    </Border>
-                                                </DataTemplate>
-                                            </ItemsControl.ItemTemplate>
-                                        </ItemsControl>
-                                    </ScrollViewer>
-                                </DockPanel>
+                <!-- Notification bell -->
+                <Panel DockPanel.Dock="Right" ClipToBounds="False">
+                    <Button x:Name="NotificationBellBtn"
+                            Background="Transparent" BorderThickness="0"
+                            Padding="8,0" VerticalAlignment="Center"
+                            ClipToBounds="False"
+                            Cursor="Hand" ToolTip.Tip="Activity Log"
+                            Click="OnBellClick">
+                        <Panel ClipToBounds="False">
+                            <TextBlock Text="&#x1F514;" FontSize="{DynamicResource EveFontTitle}" VerticalAlignment="Center" />
+                            <Border x:Name="UnreadBadge" IsVisible="False"
+                                    Background="{StaticResource EveErrorRedBrush}"
+                                    CornerRadius="7" MinWidth="14" Height="14"
+                                    HorizontalAlignment="Right" VerticalAlignment="Top"
+                                    Margin="8,-4,-6,0" Padding="3,0">
+                                <TextBlock x:Name="UnreadCountText" Text="0" FontSize="{DynamicResource EveFontCaption}"
+                                           Foreground="White" HorizontalAlignment="Center"
+                                           VerticalAlignment="Center" />
                             </Border>
-                        </Flyout>
-                    </Button.Flyout>
-                    <!-- Bell icon with badge -->
-                    <Panel ClipToBounds="False">
-                        <TextBlock Text="&#x1F514;" FontSize="{DynamicResource EveFontTitle}" VerticalAlignment="Center" />
-                        <Border x:Name="UnreadBadge" IsVisible="False"
-                                Background="{StaticResource EveErrorRedBrush}"
-                                CornerRadius="7" MinWidth="14" Height="14"
-                                HorizontalAlignment="Right" VerticalAlignment="Top"
-                                Margin="8,-4,-6,0" Padding="3,0">
-                            <TextBlock x:Name="UnreadCountText" Text="0" FontSize="{DynamicResource EveFontCaption}"
-                                       Foreground="White" HorizontalAlignment="Center"
-                                       VerticalAlignment="Center" />
+                        </Panel>
+                    </Button>
+                    <Popup x:Name="ActivityPopup" IsOpen="False"
+                           PlacementMode="AnchorAndGravity"
+                           PlacementAnchor="TopRight"
+                           PlacementGravity="TopLeft"
+                           PlacementTarget="{Binding #NotificationBellBtn}"
+                           IsLightDismissEnabled="True"
+                           WindowManagerAddShadowHint="True">
+                        <Border x:Name="ActivityFlyoutPanel"
+                                Background="{StaticResource EveBackgroundMediumBrush}"
+                                BorderBrush="{StaticResource EveBorderBrush}"
+                                BorderThickness="1" CornerRadius="6"
+                                Padding="0,0,0,8" Width="380" MaxHeight="500">
+                            <DockPanel>
+                                <!-- Header -->
+                                <Border DockPanel.Dock="Top" Padding="12,8"
+                                        BorderBrush="{StaticResource EveBorderBrush}" BorderThickness="0,0,0,1">
+                                    <DockPanel>
+                                        <StackPanel DockPanel.Dock="Right" Orientation="Horizontal" Spacing="6">
+                                            <Button x:Name="MarkReadBtn" Content="Mark Read"
+                                                    FontSize="{DynamicResource EveFontSmall}" Padding="8,2" CornerRadius="10"
+                                                    Background="Transparent"
+                                                    Foreground="{StaticResource EveTextSecondaryBrush}" />
+                                            <Button x:Name="ClearAllBtn" Content="Clear"
+                                                    FontSize="{DynamicResource EveFontSmall}" Padding="8,2" CornerRadius="10"
+                                                    Background="Transparent"
+                                                    Foreground="{StaticResource EveTextSecondaryBrush}" />
+                                        </StackPanel>
+                                        <TextBlock Text="Activity Log" FontSize="{DynamicResource EveFontSubheading}" FontWeight="SemiBold"
+                                                   Foreground="{StaticResource EveAccentPrimaryBrush}"
+                                                   VerticalAlignment="Center" />
+                                    </DockPanel>
+                                </Border>
+                                <!-- Empty state -->
+                                <TextBlock x:Name="EmptyActivityText"
+                                           Text="No recent activity"
+                                           FontSize="{DynamicResource EveFontBody}" Foreground="{StaticResource EveTextDisabledBrush}"
+                                           HorizontalAlignment="Center" VerticalAlignment="Center"
+                                           Margin="0,40" IsVisible="False" />
+                                <!-- Activity list -->
+                                <ScrollViewer VerticalScrollBarVisibility="Auto"
+                                              HorizontalScrollBarVisibility="Disabled">
+                                    <ItemsControl x:Name="ActivityItems" Margin="0,0,0,8"
+                                                  HorizontalAlignment="Stretch">
+                                        <ItemsControl.ItemTemplate>
+                                            <DataTemplate>
+                                                <Border Padding="12,6"
+                                                        BorderBrush="{StaticResource EveBorderBrush}"
+                                                        BorderThickness="0,0,0,1">
+                                                    <Grid ColumnDefinitions="*,Auto">
+                                                        <StackPanel Spacing="2">
+                                                            <TextBlock Text="{Binding Description}" FontSize="{DynamicResource EveFontBody}"
+                                                                       Foreground="{Binding DescriptionBrush}"
+                                                                       TextWrapping="Wrap"
+                                                                       MaxLines="2"
+                                                                       TextTrimming="CharacterEllipsis"
+                                                                       ToolTip.Tip="{Binding Description}" />
+                                                            <StackPanel Orientation="Horizontal" Spacing="8">
+                                                                <TextBlock Text="{Binding CharacterName}" FontSize="{DynamicResource EveFontSmall}"
+                                                                           Foreground="{StaticResource EveAccentPrimaryBrush}"
+                                                                           IsVisible="{Binding HasCharacter}" />
+                                                                <TextBlock Text="{Binding CategoryDisplay}" FontSize="{DynamicResource EveFontSmall}"
+                                                                           Foreground="{StaticResource EveTextDisabledBrush}" />
+                                                            </StackPanel>
+                                                        </StackPanel>
+                                                        <TextBlock Grid.Column="1" Text="{Binding TimeAgo}" FontSize="{DynamicResource EveFontSmall}"
+                                                                   Foreground="{StaticResource EveTextDisabledBrush}"
+                                                                   VerticalAlignment="Top" Margin="8,0,0,0" />
+                                                    </Grid>
+                                                </Border>
+                                            </DataTemplate>
+                                        </ItemsControl.ItemTemplate>
+                                    </ItemsControl>
+                                </ScrollViewer>
+                            </DockPanel>
                         </Border>
-                    </Panel>
-                </Button>
+                    </Popup>
+                </Panel>
 
                 <!-- Remaining space: next update countdown -->
                 <TextBlock x:Name="NextUpdateText" Text="" FontSize="{DynamicResource EveFontBody}"

--- a/src/EveLens.Avalonia/Views/MainWindow.axaml.cs
+++ b/src/EveLens.Avalonia/Views/MainWindow.axaml.cs
@@ -230,8 +230,17 @@ namespace EveLens.Avalonia.Views
                         needsGap = true;
                     }
 
-                    // Ungrouped at the end
+                    // Ungrouped at the end — respect saved order
                     var ungrouped = allChars.Where(c => !placed.Contains(c.Guid)).ToList();
+                    var ungroupedOrder = Settings.UngroupedCharacterOrder;
+                    if (ungroupedOrder.Count > 0)
+                    {
+                        ungrouped = ungroupedOrder
+                            .Select(guid => ungrouped.FirstOrDefault(c => c.Guid == guid))
+                            .Where(c => c != null).Select(c => c!)
+                            .Concat(ungrouped.Where(c => !ungroupedOrder.Contains(c.Guid)))
+                            .ToList();
+                    }
                     if (ungrouped.Count > 0)
                     {
                         if (needsGap)
@@ -251,6 +260,16 @@ namespace EveLens.Avalonia.Views
                 }
                 else
                 {
+                    // Respect ungrouped order
+                    var savedOrder = Settings.UngroupedCharacterOrder;
+                    if (savedOrder.Count > 0)
+                    {
+                        allChars = savedOrder
+                            .Select(guid => allChars.FirstOrDefault(c => c.Guid == guid))
+                            .Where(c => c != null).Select(c => c!)
+                            .Concat(allChars.Where(c => !savedOrder.Contains(c.Guid)))
+                            .ToList();
+                    }
                     foreach (Character character in allChars)
                     {
                         _observableCharacters.Add(new ObservableCharacter(character));

--- a/src/EveLens.Avalonia/Views/MainWindow.axaml.cs
+++ b/src/EveLens.Avalonia/Views/MainWindow.axaml.cs
@@ -38,12 +38,16 @@ using EveLens.Common.CustomEventArgs;
 using EveLens.Common.Events;
 using EveLens.Common.Notifications;
 using EveLens.Common.SettingsObjects;
+using Avalonia.Controls.Notifications;
 
 namespace EveLens.Avalonia.Views
 {
     public partial class MainWindow : Window
     {
         private const string WindowLocationKey = "MainWindow";
+        private const double ActivityFlyoutMinWidth = 320;
+        private const double ActivityFlyoutMaxWidth = 560;
+        private const double ActivityFlyoutWindowPadding = 12;
         private PixelPoint _lastPosition;
         private double _lastWidth;
         private double _lastHeight;
@@ -63,6 +67,9 @@ namespace EveLens.Avalonia.Views
         private IDisposable? _monitoredChangedSub;
         private NotificationCenterViewModel? _notificationVm;
         private IDisposable? _notificationSentSub;
+        private IDisposable? _piExpiringSub;
+        private IDisposable? _piCompletedSub;
+        private WindowNotificationManager? _toastManager;
         private IDisposable? _privacyModeSub;
         private IDisposable? _fontScaleSub;
         private readonly List<Window> _childWindows = new();
@@ -113,10 +120,26 @@ namespace EveLens.Avalonia.Views
             // Wire notification center
             _notificationVm = new NotificationCenterViewModel();
             MarkReadBtn.Click += (_, _) => { _notificationVm.MarkAllRead(); RefreshNotificationUI(); };
-            ClearAllBtn.Click += (_, _) => { _notificationVm.ClearAll(); RefreshNotificationUI(); NotificationBellBtn.Flyout?.Hide(); };
+            ClearAllBtn.Click += (_, _) => { _notificationVm.ClearAll(); RefreshNotificationUI(); ActivityPopup.IsOpen = false; };
+            ActivityPopup.Opened += (_, _) => UpdateActivityFlyoutWidth();
             _notificationVm.PropertyChanged += (_, _) =>
                 Dispatcher.UIThread.Post(RefreshNotificationUI);
             RefreshNotificationUI();
+
+            // In-app toast notifications (bottom-right corner)
+            _toastManager = new WindowNotificationManager(this)
+            {
+                Position = NotificationPosition.BottomRight,
+                MaxItems = 3
+            };
+
+            // PI alert toasts
+            _piExpiringSub = AppServices.EventAggregator?.Subscribe<CharacterPlanetaryPinsExpiringEvent>(e =>
+                Dispatcher.UIThread.Post(() => ShowPiToast(e.Character?.Name ?? "Unknown",
+                    $"{e.ExpiringPins.Count} extractor(s) expiring soon", NotificationType.Warning)));
+            _piCompletedSub = AppServices.EventAggregator?.Subscribe<CharacterPlanetaryPinsCompletedEvent>(e =>
+                Dispatcher.UIThread.Post(() => ShowPiToast(e.Character?.Name ?? "Unknown",
+                    $"{e.CompletedPins.Count} extractor(s) now idle", NotificationType.Error)));
 
             // Native OS toast notifications (cross-platform)
             _notificationSentSub = AppServices.EventAggregator?.Subscribe<NotificationSentEvent>(
@@ -696,6 +719,7 @@ namespace EveLens.Avalonia.Views
             // Tools menu
             CharCompMenuItem.Click += OnCharCompClick;
             SkillFarmMenuItem.Click += OnSkillFarmClick;
+            PlanetaryDashMenuItem.Click += OnPlanetaryDashClick;
             GlobalPlanMenuItem.Click += OnGlobalPlanClick;
             SkillConstellationMenuItem.Click += OnSkillConstellationClick;
             ClearCacheMenuItem.Click += OnClearCacheClick;
@@ -832,6 +856,56 @@ namespace EveLens.Avalonia.Views
             notifySubMenu.Items.Add(fireAccountExpiry);
             notifySubMenu.Items.Add(fireServerStatus);
             notifySubMenu.Items.Add(fireSettingsChanged);
+
+            var firePiExpiring = new MenuItem { Header = "PI Extractors Expiring (x3 chars)" };
+            firePiExpiring.Click += (_, _) =>
+            {
+                try
+                {
+                    var chars = _viewModel.Characters.Take(3).ToList();
+                    if (chars.Count == 0) return;
+                    foreach (var c in chars)
+                    {
+                        var pin = new Common.Models.PlanetaryPin[] { };
+                        AppServices.EventAggregator?.Publish(
+                            new CharacterPlanetaryPinsExpiringEvent(c, pin, TimeSpan.FromMinutes(45)));
+                        var args = new Common.Notifications.NotificationEventArgs(c, Common.Notifications.NotificationCategory.PlanetaryPinsCompleted)
+                        {
+                            Description = $"Extractor expiring in ~45m on {c.Name}'s colony.",
+                            Behaviour = Common.Notifications.NotificationBehaviour.Overwrite,
+                            Priority = Common.Notifications.NotificationPriority.Warning
+                        };
+                        AppServices.EventAggregator?.Publish(new NotificationSentEvent(args));
+                    }
+                }
+                catch (Exception ex) { Debug.WriteLine($"Error: {ex}"); }
+            };
+            notifySubMenu.Items.Add(firePiExpiring);
+
+            var firePiIdle = new MenuItem { Header = "PI Extractors Idle (x3 chars)" };
+            firePiIdle.Click += (_, _) =>
+            {
+                try
+                {
+                    var chars = _viewModel.Characters.Take(3).ToList();
+                    if (chars.Count == 0) return;
+                    foreach (var c in chars)
+                    {
+                        var pin = new Common.Models.PlanetaryPin[] { };
+                        AppServices.EventAggregator?.Publish(
+                            new CharacterPlanetaryPinsCompletedEvent(c, pin));
+                        var args = new Common.Notifications.NotificationEventArgs(c, Common.Notifications.NotificationCategory.PlanetaryPinsCompleted)
+                        {
+                            Description = $"{c.Name}: 2 extractors now idle.",
+                            Behaviour = Common.Notifications.NotificationBehaviour.Overwrite,
+                            Priority = Common.Notifications.NotificationPriority.Warning
+                        };
+                        AppServices.EventAggregator?.Publish(new NotificationSentEvent(args));
+                    }
+                }
+                catch (Exception ex) { Debug.WriteLine($"Error: {ex}"); }
+            };
+            notifySubMenu.Items.Add(firePiIdle);
 
             // ── Dialogs ──
             var dialogSubMenu = new MenuItem { Header = "Open Dialogs" };
@@ -1861,6 +1935,19 @@ namespace EveLens.Avalonia.Views
             }
         }
 
+        private async void OnPlanetaryDashClick(object? sender, RoutedEventArgs e)
+        {
+            try
+            {
+                var window = new Dialogs.PlanetaryDashboardWindow();
+                await window.ShowDialog(this);
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"Error opening Planetary Dashboard: {ex}");
+            }
+        }
+
         private async void OnGlobalPlanClick(object? sender, RoutedEventArgs e)
         {
             try
@@ -2173,6 +2260,44 @@ namespace EveLens.Avalonia.Views
             EmptyActivityText.IsVisible = entries.Count == 0;
         }
 
+        private void OnBellClick(object? sender, global::Avalonia.Interactivity.RoutedEventArgs e)
+        {
+            ActivityPopup.IsOpen = !ActivityPopup.IsOpen;
+        }
+
+        private void ShowPiToast(string characterName, string message, NotificationType type)
+        {
+            _toastManager?.Show(new Notification(
+                $"PI: {characterName}",
+                message,
+                type,
+                TimeSpan.FromSeconds(8)));
+        }
+
+        private void UpdateActivityFlyoutWidth()
+        {
+            double availableWidth = Bounds.Width - (ActivityFlyoutWindowPadding * 2);
+            Point? buttonRight = NotificationBellBtn.TranslatePoint(
+                new Point(NotificationBellBtn.Bounds.Width, 0), this);
+
+            if (buttonRight.HasValue)
+            {
+                availableWidth = Math.Min(
+                    availableWidth,
+                    buttonRight.Value.X - ActivityFlyoutWindowPadding);
+            }
+
+            if (double.IsNaN(availableWidth) || double.IsInfinity(availableWidth) || availableWidth <= 0)
+                availableWidth = ActivityFlyoutMaxWidth;
+
+            double targetWidth = Math.Min(ActivityFlyoutMaxWidth, availableWidth);
+            targetWidth = Math.Max(220, targetWidth);
+
+            ActivityFlyoutPanel.MinWidth = Math.Min(ActivityFlyoutMinWidth, targetWidth);
+            ActivityFlyoutPanel.Width = targetWidth;
+            ActivityFlyoutPanel.MaxWidth = targetWidth;
+        }
+
         internal async void DeleteCharacterWithConfirmation(Character character)
         {
             try
@@ -2321,6 +2446,8 @@ namespace EveLens.Avalonia.Views
             }
         }
 
+        private DateTime _lastPiOsToast = DateTime.MinValue;
+
         private void OnNotificationSent(NotificationSentEvent e)
         {
             try
@@ -2329,6 +2456,17 @@ namespace EveLens.Avalonia.Views
                     return;
 
                 var args = e.Args;
+
+                // PI: one summary OS toast max every 5 minutes
+                if (args.Category == Common.Notifications.NotificationCategory.PlanetaryPinsCompleted)
+                {
+                    if ((DateTime.UtcNow - _lastPiOsToast).TotalMinutes < 5)
+                        return;
+                    _lastPiOsToast = DateTime.UtcNow;
+                    NativeNotificationService.Show("EveLens", "PI needs attention. Please check.");
+                    return;
+                }
+
                 string title = args.SenderCharacter?.Name ?? "EveLens";
                 string message = args.Description ?? args.Category.ToString();
                 NativeNotificationService.Show(title, message);

--- a/src/EveLens.Avalonia/Views/PlanEditor/PlanUnifiedView.axaml.cs
+++ b/src/EveLens.Avalonia/Views/PlanEditor/PlanUnifiedView.axaml.cs
@@ -239,8 +239,8 @@ namespace EveLens.Avalonia.Views.PlanEditor
                         var deltas = new List<AttributeDelta>();
                         var allAttrs = new[]
                         {
-                            EveAttribute.Intelligence, EveAttribute.Perception,
-                            EveAttribute.Charisma, EveAttribute.Willpower, EveAttribute.Memory
+                            EveAttribute.Perception, EveAttribute.Memory,
+                            EveAttribute.Willpower, EveAttribute.Intelligence, EveAttribute.Charisma
                         };
                         foreach (var attr in allAttrs)
                         {
@@ -552,9 +552,9 @@ namespace EveLens.Avalonia.Views.PlanEditor
 
         private static string FormatRemapAttributes(RemappingPoint rp)
         {
-            return $"INT {rp[EveAttribute.Intelligence]}  PER {rp[EveAttribute.Perception]}  " +
-                   $"WIL {rp[EveAttribute.Willpower]}  CHA {rp[EveAttribute.Charisma]}  " +
-                   $"MEM {rp[EveAttribute.Memory]}";
+            return $"PER {rp[EveAttribute.Perception]}  MEM {rp[EveAttribute.Memory]}  " +
+                   $"WIL {rp[EveAttribute.Willpower]}  INT {rp[EveAttribute.Intelligence]}  " +
+                   $"CHA {rp[EveAttribute.Charisma]}";
         }
 
         #endregion
@@ -624,7 +624,7 @@ namespace EveLens.Avalonia.Views.PlanEditor
                 // No changes — show all attributes
                 line.Children.Add(new TextBlock
                 {
-                    Text = $"INT\u2192{divider.Intelligence}  PER\u2192{divider.Perception}  WIL\u2192{divider.Willpower}  CHA\u2192{divider.Charisma}  MEM\u2192{divider.Memory}",
+                    Text = $"PER\u2192{divider.Perception}  MEM\u2192{divider.Memory}  WIL\u2192{divider.Willpower}  INT\u2192{divider.Intelligence}  CHA\u2192{divider.Charisma}",
                     FontSize = FontScaleService.Caption,
                     Foreground = new SolidColorBrush(Color.Parse("#FFD0D0D0")),
                     VerticalAlignment = VerticalAlignment.Center,
@@ -666,8 +666,8 @@ namespace EveLens.Avalonia.Views.PlanEditor
             border.Child = line;
 
             // Tooltip with full attribute breakdown
-            var tooltipText = $"Remap to: INT {divider.Intelligence}  PER {divider.Perception}  " +
-                              $"WIL {divider.Willpower}  CHA {divider.Charisma}  MEM {divider.Memory}";
+            var tooltipText = $"Remap to: PER {divider.Perception}  MEM {divider.Memory}  " +
+                              $"WIL {divider.Willpower}  INT {divider.Intelligence}  CHA {divider.Charisma}";
             if (!string.IsNullOrEmpty(divider.AvailabilityText))
                 tooltipText += $"\n{divider.AvailabilityText}";
             if (divider.Deltas.Count > 0)
@@ -1979,8 +1979,8 @@ namespace EveLens.Avalonia.Views.PlanEditor
 
                 var attrs = new[]
                 {
-                    EveAttribute.Intelligence, EveAttribute.Perception,
-                    EveAttribute.Charisma, EveAttribute.Willpower, EveAttribute.Memory
+                    EveAttribute.Perception, EveAttribute.Memory,
+                    EveAttribute.Willpower, EveAttribute.Intelligence, EveAttribute.Charisma
                 };
 
                 // Compact result line: ⚡ 47d → 38d  ✓ -9d 4h
@@ -2269,8 +2269,8 @@ namespace EveLens.Avalonia.Views.PlanEditor
 
             var attrs = new[]
             {
-                EveAttribute.Intelligence, EveAttribute.Perception,
-                EveAttribute.Charisma, EveAttribute.Willpower, EveAttribute.Memory
+                EveAttribute.Perception, EveAttribute.Memory,
+                EveAttribute.Willpower, EveAttribute.Intelligence, EveAttribute.Charisma
             };
 
             AddThinDivider("Manual adjustment");

--- a/src/EveLens.Common/Collections/Global/GlobalNotificationCollection.cs
+++ b/src/EveLens.Common/Collections/Global/GlobalNotificationCollection.cs
@@ -1429,16 +1429,51 @@ namespace EveLens.Common.Collections.Global
         internal void NotifyCharacterPlanetaryPinCompleted(Character character,
             IEnumerable<PlanetaryPin> pinsCompleted)
         {
-            // PI idle is a persistent state, not a one-time event.
-            // Update the notification collection (for internal tracking) but don't
-            // publish to the activity log — the PI tab exists for checking idle colonies.
-            var notification = new PlanetaryPinsNotificationEventArgs(character, pinsCompleted)
+            var pins = pinsCompleted.ToList();
+            int count = pins.Count;
+            var planets = string.Join(", ", pins.Select(p => p.Colony?.PlanetName ?? "Unknown").Distinct().Take(3));
+            if (pins.Select(p => p.Colony?.PlanetName).Distinct().Count() > 3)
+                planets += "...";
+
+            string description = count == 1
+                ? $"Extractor idle on {planets}."
+                : $"{count} extractors now idle ({planets}).";
+
+            var notification = new PlanetaryPinsNotificationEventArgs(character, pins)
             {
+                Description = description,
                 Behaviour = NotificationBehaviour.Overwrite,
-                Priority = NotificationPriority.Information
+                Priority = NotificationPriority.Warning
             };
             InvalidateCore(notification.InvalidationKey);
             Items.Add(notification);
+            Notify(notification);
+        }
+
+        internal void NotifyCharacterPlanetaryPinsExpiring(Character character,
+            IEnumerable<PlanetaryPin> pinsExpiring, TimeSpan leadTime)
+        {
+            var pins = pinsExpiring.ToList();
+            int count = pins.Count;
+            var planets = string.Join(", ", pins.Select(p => p.Colony?.PlanetName ?? "Unknown").Distinct().Take(3));
+            if (pins.Select(p => p.Colony?.PlanetName).Distinct().Count() > 3)
+                planets += "...";
+
+            string timeLeft = leadTime.TotalHours >= 1
+                ? $"{(int)leadTime.TotalHours}h {leadTime.Minutes}m"
+                : $"{leadTime.Minutes}m";
+
+            string description = count == 1
+                ? $"Extractor expiring in ~{timeLeft} on {planets}."
+                : $"{count} extractors expiring in ~{timeLeft} ({planets}).";
+
+            var notification = new NotificationEventArgs(character, NotificationCategory.PlanetaryPinsCompleted)
+            {
+                Description = description,
+                Behaviour = NotificationBehaviour.Overwrite,
+                Priority = NotificationPriority.Warning
+            };
+            Notify(notification);
         }
 
 

--- a/src/EveLens.Common/Events/CommonEvents.cs
+++ b/src/EveLens.Common/Events/CommonEvents.cs
@@ -3,6 +3,7 @@
 // Built with Claude Code (Anthropic)
 // Licensed under GPL v2 — see LICENSE for details
 
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
@@ -410,6 +411,23 @@ namespace EveLens.Common.Events
             : base(character)
         {
             CompletedPins = completedPins.ToList().AsReadOnly();
+        }
+    }
+
+    /// <summary>
+    /// Fired when extractor pins are approaching expiry (within the configured lead time).
+    /// Allows UI to show pre-expiry warnings so players can plan to log in.
+    /// </summary>
+    public sealed class CharacterPlanetaryPinsExpiringEvent : CharacterEventBase
+    {
+        public ReadOnlyCollection<PlanetaryPin> ExpiringPins { get; }
+        public TimeSpan LeadTime { get; }
+
+        public CharacterPlanetaryPinsExpiringEvent(Character character, IEnumerable<PlanetaryPin> expiringPins, TimeSpan leadTime)
+            : base(character)
+        {
+            ExpiringPins = expiringPins.ToList().AsReadOnly();
+            LeadTime = leadTime;
         }
     }
 

--- a/src/EveLens.Common/Helpers/FormattingHelper.cs
+++ b/src/EveLens.Common/Helpers/FormattingHelper.cs
@@ -1,0 +1,29 @@
+// EveLens — Character Intelligence for EVE Online
+// Copyright © 2006-2021 EVEMon Development Team, © 2025-2026 Alia Collins
+// Built with Claude Code (Anthropic)
+// Licensed under GPL v2 — see LICENSE for details
+
+using System;
+
+namespace EveLens.Common.Helpers
+{
+    /// <summary>
+    /// Shared formatting utilities for ISK values and other numeric displays.
+    /// </summary>
+    public static class FormattingHelper
+    {
+        /// <summary>
+        /// Formats an ISK value with appropriate suffix (B/M/K) for compact display.
+        /// </summary>
+        public static string FormatIsk(double isk)
+        {
+            if (Math.Abs(isk) >= 1_000_000_000)
+                return $"{isk / 1_000_000_000:F1}B";
+            if (Math.Abs(isk) >= 1_000_000)
+                return $"{isk / 1_000_000:F1}M";
+            if (Math.Abs(isk) >= 1_000)
+                return $"{isk / 1_000:F1}K";
+            return $"{isk:F0}";
+        }
+    }
+}

--- a/src/EveLens.Common/Helpers/SettingsFileManager.Decomposer.cs
+++ b/src/EveLens.Common/Helpers/SettingsFileManager.Decomposer.cs
@@ -42,6 +42,9 @@ namespace EveLens.Common.Helpers
                     Name = g.Name,
                     CharacterGuids = g.CharacterGuids.ToList()
                 }).ToList(),
+                UngroupedCharacterOrder = settings.UngroupedCharacterOrder?.Count > 0
+                    ? new List<Guid>(settings.UngroupedCharacterOrder)
+                    : null,
                 SSOClientID = settings.SSOClientID,
                 SSOClientSecret = settings.SSOClientSecret,
                 GlobalPlanTemplates = settings.GlobalPlanTemplates.Select(t => new JsonGlobalPlanTemplate

--- a/src/EveLens.Common/Helpers/SettingsFileManager.Loader.cs
+++ b/src/EveLens.Common/Helpers/SettingsFileManager.Loader.cs
@@ -198,6 +198,10 @@ namespace EveLens.Common.Helpers
                     settings.CharacterGroups.Add(cgs);
                 }
 
+                // Restore ungrouped character order
+                if (config.UngroupedCharacterOrder != null)
+                    settings.UngroupedCharacterOrder = new List<Guid>(config.UngroupedCharacterOrder);
+
                 // Restore global plan templates
                 foreach (var jt in config.GlobalPlanTemplates ?? new List<JsonGlobalPlanTemplate>())
                 {

--- a/src/EveLens.Common/Helpers/SettingsFileManagerTypes.cs
+++ b/src/EveLens.Common/Helpers/SettingsFileManagerTypes.cs
@@ -44,6 +44,7 @@ namespace EveLens.Common.Helpers
         public string? EsiScopePreset { get; set; }
         public List<string>? EsiCustomScopes { get; set; }
         public List<JsonCharacterGroupSettings>? CharacterGroups { get; set; }
+        public List<Guid>? UngroupedCharacterOrder { get; set; }
 
         // SSO credentials (custom overrides persisted from user settings)
         public string? SSOClientID { get; set; }

--- a/src/EveLens.Common/Models/Collections/PlanetaryColonyCollection.cs
+++ b/src/EveLens.Common/Models/Collections/PlanetaryColonyCollection.cs
@@ -88,28 +88,54 @@ namespace EveLens.Common.Models.Collections
         #region Helper Methods
 
         /// <summary>
-        /// Notify the user on a pin completion.
+        /// Notify the user on a pin completion and check for approaching expiry.
         /// </summary>
         private void UpdateOnTimerTick()
         {
-            // We exit if there are no pins
             if (!Items.Any())
                 return;
 
-            // Add the not notified idle pins to the completed list
-            var pinsCompleted = Items.SelectMany(x => x.Pins).Where(pin => pin.State !=
+            var allPins = Items.SelectMany(x => x.Pins).ToList();
+
+            // Check for completed pins (post-expiry notification)
+            var pinsCompleted = allPins.Where(pin => pin.State !=
                 PlanetaryPinState.None && pin.TTC.Length == 0 && !pin.NotificationSend).ToList();
 
             pinsCompleted.ForEach(pin => pin.NotificationSend = true);
 
-            // We exit if no pins have finished
-            if (!pinsCompleted.Any())
+            if (pinsCompleted.Any())
+            {
+                AppServices.TraceService?.Trace(m_ccpCharacter.Name);
+                m_ccpCharacter.OnPlanetaryPinsCompleted(pinsCompleted);
+                AppServices.EventAggregator?.Publish(new CommonEvents.CharacterPlanetaryPinsCompletedEvent(m_ccpCharacter, pinsCompleted));
+            }
+
+            // Check for approaching expiry (pre-expiry alert)
+            CheckPreExpiryAlerts(allPins);
+        }
+
+        private void CheckPreExpiryAlerts(List<PlanetaryPin> allPins)
+        {
+            var settings = Settings.UI?.MainWindow?.Planetary;
+            if (settings == null || !settings.AlertsEnabled || settings.AlertLeadTimeMinutes <= 0)
                 return;
 
-            // Fires the event regarding the character's pins finished
-            AppServices.TraceService?.Trace(m_ccpCharacter.Name);
-            m_ccpCharacter.OnPlanetaryPinsCompleted(pinsCompleted);
-            AppServices.EventAggregator?.Publish(new CommonEvents.CharacterPlanetaryPinsCompletedEvent(m_ccpCharacter, pinsCompleted));
+            var leadTime = TimeSpan.FromMinutes(settings.AlertLeadTimeMinutes);
+            var now = DateTime.UtcNow;
+
+            var pinsExpiring = allPins.Where(pin =>
+                pin.State == PlanetaryPinState.Extracting &&
+                !pin.PreExpiryAlertSent &&
+                pin.ExpiryTime > now &&
+                (pin.ExpiryTime - now) <= leadTime).ToList();
+
+            if (!pinsExpiring.Any())
+                return;
+
+            pinsExpiring.ForEach(pin => pin.PreExpiryAlertSent = true);
+            AppServices.EventAggregator?.Publish(
+                new CommonEvents.CharacterPlanetaryPinsExpiringEvent(m_ccpCharacter, pinsExpiring, leadTime));
+            AppServices.Notifications.NotifyCharacterPlanetaryPinsExpiring(m_ccpCharacter, pinsExpiring, leadTime);
         }
 
         #endregion

--- a/src/EveLens.Common/Models/PlanetaryPin.cs
+++ b/src/EveLens.Common/Models/PlanetaryPin.cs
@@ -229,9 +229,14 @@ namespace EveLens.Common.Models
         public string GroupName { get; }
 
         /// <summary>
-        /// Gets true if we have notified the user.
+        /// Gets true if we have notified the user (post-expiry).
         /// </summary>
         public bool NotificationSend { get; set; }
+
+        /// <summary>
+        /// Gets true if we have sent the pre-expiry warning.
+        /// </summary>
+        public bool PreExpiryAlertSent { get; set; }
 
         #endregion
 

--- a/src/EveLens.Common/Models/PlanetaryRoute.cs
+++ b/src/EveLens.Common/Models/PlanetaryRoute.cs
@@ -23,6 +23,8 @@ namespace EveLens.Common.Models
             ID = src.RouteID;
             SourcePinID = src.SourcePinID;
             DestinationPinID = src.DestinationPinID;
+            ContentTypeID = (int)src.ContentTypeID;
+            Quantity = src.Quantity;
         }
 
         #endregion
@@ -61,6 +63,16 @@ namespace EveLens.Common.Models
         /// The destination pin identifier.
         /// </value>
         public long DestinationPinID { get; private set; }
+
+        /// <summary>
+        /// Gets the type ID of the material being routed.
+        /// </summary>
+        public int ContentTypeID { get; private set; }
+
+        /// <summary>
+        /// Gets the quantity of material per route cycle.
+        /// </summary>
+        public int Quantity { get; private set; }
 
         #endregion
 

--- a/src/EveLens.Common/Models/RemappingPoint.cs
+++ b/src/EveLens.Common/Models/RemappingPoint.cs
@@ -79,7 +79,7 @@ namespace EveLens.Common.Models
             m_attributes[(int)EveAttribute.Willpower] = willpower;
             m_attributes[(int)EveAttribute.Memory] = memory;
             Status = RemappingPointStatus.UpToDate;
-            m_description = $"INT {intelligence}  PER {perception}  CHA {charisma}  WIL {willpower}  MEM {memory}";
+            m_description = $"PER {perception}  MEM {memory}  WIL {willpower}  INT {intelligence}  CHA {charisma}";
         }
 
         /// <summary>

--- a/src/EveLens.Common/Properties/Resources.Designer.cs
+++ b/src/EveLens.Common/Properties/Resources.Designer.cs
@@ -607,8 +607,7 @@ namespace EveLens.Common.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Error logging in to EVE SSO.
-        ///If you changed your password, you must log in again using File &gt; Add Character..
+        ///   Looks up a localized string similar to EVE SSO login failed. Re-authenticate via File &gt; Add Character..
         /// </summary>
         public static string ErrorSSO {
             get {

--- a/src/EveLens.Common/Properties/Resources.resx
+++ b/src/EveLens.Common/Properties/Resources.resx
@@ -363,8 +363,7 @@ If you changed your password, you must log in again using File &gt; Add Characte
     <value>Error querying the known skills of {0}.</value>
   </data>
   <data name="ErrorSSO" xml:space="preserve">
-    <value>Error logging in to EVE SSO.
-If you changed your password, you must log in again using File &gt; Add Character.</value>
+    <value>EVE SSO login failed. Re-authenticate via File &gt; Add Character.</value>
   </data>
   <data name="ErrorStandings" xml:space="preserve">
     <value>Error querying the standings of {0}.</value>

--- a/src/EveLens.Common/Serialization/Settings/SerializableSettings.cs
+++ b/src/EveLens.Common/Serialization/Settings/SerializableSettings.cs
@@ -3,6 +3,7 @@
 // Built with Claude Code (Anthropic)
 // Licensed under GPL v2 — see LICENSE for details
 
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Xml.Serialization;
@@ -138,6 +139,10 @@ namespace EveLens.Common.Serialization.Settings
         [XmlArray("characterGroups")]
         [XmlArrayItem("group")]
         public Collection<CharacterGroupSettings> CharacterGroups => m_characterGroups;
+
+        [XmlArray("ungroupedCharacterOrder")]
+        [XmlArrayItem("guid")]
+        public List<Guid> UngroupedCharacterOrder { get; set; } = new List<Guid>();
 
         [XmlArray("globalPlanTemplates")]
         [XmlArrayItem("template")]

--- a/src/EveLens.Common/Services/Planetary/ColonyEconomicsService.cs
+++ b/src/EveLens.Common/Services/Planetary/ColonyEconomicsService.cs
@@ -1,0 +1,202 @@
+// EveLens — Character Intelligence for EVE Online
+// Copyright © 2006-2021 EVEMon Development Team, © 2025-2026 Alia Collins
+// Built with Claude Code (Anthropic)
+// Licensed under GPL v2 — see LICENSE for details
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using EveLens.Common.MarketPricer;
+using EveLens.Common.Models;
+
+namespace EveLens.Common.Services.Planetary
+{
+    /// <summary>
+    /// Calculates economic metrics for PI colonies by combining extraction yields,
+    /// market prices, and tax rates into actionable ISK/hr figures.
+    /// </summary>
+    public sealed class ColonyEconomicsService
+    {
+        private readonly Func<int, double> _priceProvider;
+        private readonly int _customsCodeExpertiseLevel;
+        private readonly double? _pocoTaxOverride;
+
+        /// <summary>
+        /// Creates a new economics service for a specific character context.
+        /// </summary>
+        /// <param name="customsCodeExpertiseLevel">Character's CCE skill level (0-5)</param>
+        /// <param name="pocoTaxOverride">User-configured POCO tax rate, null for NPC default</param>
+        /// <param name="priceProvider">Optional price lookup override (for testing)</param>
+        public ColonyEconomicsService(int customsCodeExpertiseLevel, double? pocoTaxOverride = null, Func<int, double> priceProvider = null)
+        {
+            _customsCodeExpertiseLevel = Math.Clamp(customsCodeExpertiseLevel, 0, 5);
+            _pocoTaxOverride = pocoTaxOverride;
+            _priceProvider = priceProvider ?? DefaultPriceProvider;
+        }
+
+        /// <summary>
+        /// Calculates full economics for a colony analysis.
+        /// </summary>
+        public ColonyEconomics Calculate(ColonyAnalysis analysis)
+        {
+            if (analysis == null || analysis.Colony == null)
+                return ColonyEconomics.Empty;
+
+            float securityStatus = analysis.Colony.SolarSystem?.SecurityLevel ?? 1.0f;
+            double taxRate = PlanetaryTaxCalculator.GetTotalExportTaxRate(
+                securityStatus, _customsCodeExpertiseLevel, _pocoTaxOverride);
+
+            var outputItems = GetFinalOutputs(analysis);
+            double grossIskPerHour = 0;
+            double taxCostPerHour = 0;
+
+            foreach (var output in outputItems)
+            {
+                double price = _priceProvider(output.TypeID);
+                double iskPerHour = output.UnitsPerHour * price;
+                grossIskPerHour += iskPerHour;
+
+                // Tax is based on CCP base value, not market price
+                // For simplicity, use market price as proxy (CCP base values aren't in our data)
+                double taxPerUnit = price * taxRate;
+                taxCostPerHour += output.UnitsPerHour * taxPerUnit;
+            }
+
+            double netIskPerHour = grossIskPerHour - taxCostPerHour;
+
+            return new ColonyEconomics(
+                grossIskPerHour: grossIskPerHour,
+                taxCostPerHour: taxCostPerHour,
+                netIskPerHour: netIskPerHour,
+                taxRate: taxRate,
+                securityStatus: securityStatus,
+                securityClass: PlanetaryTaxCalculator.GetSecurityClass(securityStatus),
+                outputs: outputItems,
+                timeUntilIdle: analysis.TimeUntilFirstIdle,
+                health: analysis.Health);
+        }
+
+        /// <summary>
+        /// Calculates a quick ISK estimate for an extractor based on its output type and current rate.
+        /// </summary>
+        public double EstimateExtractorIskPerHour(ExtractorInfo extractor)
+        {
+            if (extractor == null || extractor.OutputTypeID <= 0)
+                return 0;
+
+            double price = _priceProvider(extractor.OutputTypeID);
+            return extractor.CurrentYieldPerHour * price;
+        }
+
+        /// <summary>
+        /// Determines the "final" outputs of the colony — the highest-tier products being made.
+        /// If there are factories, the final output is the highest-tier factory output.
+        /// If only extractors, the output is raw materials.
+        /// </summary>
+        private List<OutputItem> GetFinalOutputs(ColonyAnalysis analysis)
+        {
+            var outputs = new List<OutputItem>();
+
+            if (analysis.Factories.Count > 0)
+            {
+                // Find highest-tier factories — their outputs are what gets exported
+                var maxTier = analysis.Factories.Max(f => f.Tier);
+                var topFactories = analysis.Factories.Where(f => f.Tier == maxTier);
+
+                foreach (var factory in topFactories)
+                {
+                    outputs.Add(new OutputItem(
+                        factory.Schematic.Output.TypeID,
+                        factory.Schematic.Output.TypeName,
+                        factory.OutputPerHour,
+                        factory.Tier));
+                }
+            }
+            else
+            {
+                // No factories — raw extractor output
+                foreach (var extractor in analysis.Extractors)
+                {
+                    if (extractor.OutputTypeID > 0)
+                    {
+                        outputs.Add(new OutputItem(
+                            extractor.OutputTypeID,
+                            extractor.OutputTypeName,
+                            extractor.CurrentYieldPerHour,
+                            ProductionTier.Basic));
+                    }
+                }
+            }
+
+            return outputs;
+        }
+
+        private static double DefaultPriceProvider(int typeId)
+        {
+            // Use first available pricer
+            var providers = ItemPricer.Providers;
+            foreach (var provider in providers)
+            {
+                if (provider.Queried)
+                {
+                    double price = provider.GetPriceByTypeID(typeId);
+                    if (price > 0) return price;
+                }
+            }
+            return 0;
+        }
+    }
+
+    #region Economics Result Types
+
+    public sealed class ColonyEconomics
+    {
+        public static readonly ColonyEconomics Empty = new(0, 0, 0, 0, 0, PlanetaryTaxCalculator.SecurityClass.HighSec, new(), TimeSpan.Zero, ColonyHealthStatus.NoExtractors);
+
+        public double GrossIskPerHour { get; }
+        public double TaxCostPerHour { get; }
+        public double NetIskPerHour { get; }
+        public double GrossIskPerDay => GrossIskPerHour * 24;
+        public double TaxCostPerDay => TaxCostPerHour * 24;
+        public double NetIskPerDay => NetIskPerHour * 24;
+        public double TaxRate { get; }
+        public float SecurityStatus { get; }
+        public PlanetaryTaxCalculator.SecurityClass SecurityClass { get; }
+        public IReadOnlyList<OutputItem> Outputs { get; }
+        public TimeSpan TimeUntilIdle { get; }
+        public ColonyHealthStatus Health { get; }
+
+        internal ColonyEconomics(double grossIskPerHour, double taxCostPerHour, double netIskPerHour,
+            double taxRate, float securityStatus, PlanetaryTaxCalculator.SecurityClass securityClass,
+            List<OutputItem> outputs, TimeSpan timeUntilIdle, ColonyHealthStatus health)
+        {
+            GrossIskPerHour = grossIskPerHour;
+            TaxCostPerHour = taxCostPerHour;
+            NetIskPerHour = netIskPerHour;
+            TaxRate = taxRate;
+            SecurityStatus = securityStatus;
+            SecurityClass = securityClass;
+            Outputs = outputs;
+            TimeUntilIdle = timeUntilIdle;
+            Health = health;
+        }
+    }
+
+    public sealed class OutputItem
+    {
+        public int TypeID { get; }
+        public string TypeName { get; }
+        public double UnitsPerHour { get; }
+        public ProductionTier Tier { get; }
+
+        internal OutputItem(int typeId, string typeName, double unitsPerHour, ProductionTier tier)
+        {
+            TypeID = typeId;
+            TypeName = typeName;
+            UnitsPerHour = unitsPerHour;
+            Tier = tier;
+        }
+    }
+
+    #endregion
+}

--- a/src/EveLens.Common/Services/Planetary/ExtractionCalculator.cs
+++ b/src/EveLens.Common/Services/Planetary/ExtractionCalculator.cs
@@ -1,0 +1,190 @@
+// EveLens — Character Intelligence for EVE Online
+// Copyright © 2006-2021 EVEMon Development Team, © 2025-2026 Alia Collins
+// Built with Claude Code (Anthropic)
+// Licensed under GPL v2 — see LICENSE for details
+
+using System;
+using System.Collections.Generic;
+
+namespace EveLens.Common.Services.Planetary
+{
+    /// <summary>
+    /// Calculates accurate extraction yields using the official EVE Online decay+noise formula.
+    /// The ESI qty_per_cycle value is NOT the actual per-cycle output — real extraction follows
+    /// a decay curve with sinusoidal noise that front-loads yield and tapers over time.
+    /// </summary>
+    public static class ExtractionCalculator
+    {
+        // Dogma attribute 1683 — controls how fast yield decays over time
+        private const double DecayFactor = 0.012;
+
+        // Dogma attribute 1687 — amplitude of the sinusoidal noise overlay
+        private const double NoiseFactor = 0.8;
+
+        /// <summary>
+        /// Calculates the yield for each individual cycle of an extraction program.
+        /// This implements the official EVE formula with exponential decay and
+        /// triple-cosine noise modulation.
+        /// </summary>
+        /// <param name="qtyPerCycle">Base quantity per cycle from ESI (extractor_details.qty_per_cycle)</param>
+        /// <param name="cycleTimeSeconds">Cycle duration in seconds from ESI (extractor_details.cycle_time)</param>
+        /// <param name="totalDurationSeconds">Total program duration in seconds (expiry_time - install_time)</param>
+        /// <returns>Array of per-cycle yields (floored integers), index 0 = first cycle</returns>
+        public static int[] CalculateCycleYields(int qtyPerCycle, int cycleTimeSeconds, int totalDurationSeconds)
+        {
+            if (qtyPerCycle <= 0 || cycleTimeSeconds <= 0 || totalDurationSeconds <= 0)
+                return Array.Empty<int>();
+
+            int numCycles = totalDurationSeconds / cycleTimeSeconds;
+            if (numCycles <= 0)
+                return Array.Empty<int>();
+
+            double barWidth = cycleTimeSeconds / 900.0;
+            var values = new int[numCycles];
+
+            for (int i = 0; i < numCycles; i++)
+            {
+                values[i] = CalculateSingleCycleYield(qtyPerCycle, barWidth, i);
+            }
+
+            return values;
+        }
+
+        /// <summary>
+        /// Calculates the total yield across the entire extraction program.
+        /// Significantly lower than naive qty_per_cycle * numCycles (typically 30-50% less).
+        /// </summary>
+        public static long CalculateTotalYield(int qtyPerCycle, int cycleTimeSeconds, int totalDurationSeconds)
+        {
+            var yields = CalculateCycleYields(qtyPerCycle, cycleTimeSeconds, totalDurationSeconds);
+            long total = 0;
+            for (int i = 0; i < yields.Length; i++)
+                total += yields[i];
+            return total;
+        }
+
+        /// <summary>
+        /// Calculates the remaining yield from a given point in the extraction program.
+        /// Used to show "what you'll still get if you don't restart".
+        /// </summary>
+        /// <param name="qtyPerCycle">Base quantity per cycle from ESI</param>
+        /// <param name="cycleTimeSeconds">Cycle duration in seconds</param>
+        /// <param name="totalDurationSeconds">Total program duration</param>
+        /// <param name="elapsedSeconds">How many seconds have already elapsed since install_time</param>
+        /// <returns>Sum of yields for remaining cycles</returns>
+        public static long CalculateRemainingYield(int qtyPerCycle, int cycleTimeSeconds, int totalDurationSeconds, int elapsedSeconds)
+        {
+            if (qtyPerCycle <= 0 || cycleTimeSeconds <= 0 || totalDurationSeconds <= 0)
+                return 0;
+
+            int numCycles = totalDurationSeconds / cycleTimeSeconds;
+            int completedCycles = Math.Min(elapsedSeconds / cycleTimeSeconds, numCycles);
+
+            if (completedCycles >= numCycles)
+                return 0;
+
+            double barWidth = cycleTimeSeconds / 900.0;
+            long remaining = 0;
+
+            for (int i = completedCycles; i < numCycles; i++)
+            {
+                remaining += CalculateSingleCycleYield(qtyPerCycle, barWidth, i);
+            }
+
+            return remaining;
+        }
+
+        /// <summary>
+        /// Calculates the average yield per hour at a specific point in the program.
+        /// Useful for showing current extraction rate vs. initial rate.
+        /// </summary>
+        /// <param name="qtyPerCycle">Base quantity per cycle from ESI</param>
+        /// <param name="cycleTimeSeconds">Cycle duration in seconds</param>
+        /// <param name="cycleIndex">Which cycle to calculate rate for (0-based)</param>
+        /// <returns>Units per hour at that cycle</returns>
+        public static double CalculateYieldPerHourAtCycle(int qtyPerCycle, int cycleTimeSeconds, int cycleIndex)
+        {
+            if (qtyPerCycle <= 0 || cycleTimeSeconds <= 0 || cycleIndex < 0)
+                return 0;
+
+            double barWidth = cycleTimeSeconds / 900.0;
+            int cycleYield = CalculateSingleCycleYield(qtyPerCycle, barWidth, cycleIndex);
+            double cyclesPerHour = 3600.0 / cycleTimeSeconds;
+
+            return cycleYield * cyclesPerHour;
+        }
+
+        /// <summary>
+        /// Generates data points for rendering the yield decay curve.
+        /// Returns normalized values (0.0 to 1.0) relative to the first cycle's yield,
+        /// suitable for sparkline or chart rendering.
+        /// </summary>
+        /// <param name="qtyPerCycle">Base quantity per cycle from ESI</param>
+        /// <param name="cycleTimeSeconds">Cycle duration in seconds</param>
+        /// <param name="totalDurationSeconds">Total program duration</param>
+        /// <param name="maxDataPoints">Maximum number of data points (for UI performance)</param>
+        /// <returns>Array of normalized yield values (0.0 to 1.0)</returns>
+        public static double[] GenerateYieldCurve(int qtyPerCycle, int cycleTimeSeconds, int totalDurationSeconds, int maxDataPoints = 48)
+        {
+            var yields = CalculateCycleYields(qtyPerCycle, cycleTimeSeconds, totalDurationSeconds);
+            if (yields.Length == 0)
+                return Array.Empty<double>();
+
+            int step = Math.Max(1, yields.Length / maxDataPoints);
+            int pointCount = (yields.Length + step - 1) / step;
+            var curve = new double[pointCount];
+
+            double maxYield = yields[0];
+            if (maxYield <= 0)
+                return Array.Empty<double>();
+
+            for (int i = 0; i < pointCount; i++)
+            {
+                int idx = i * step;
+                if (idx < yields.Length)
+                    curve[i] = yields[idx] / maxYield;
+            }
+
+            return curve;
+        }
+
+        /// <summary>
+        /// Calculates the naive (incorrect) total yield assuming no decay and maximum noise.
+        /// This represents what you'd get if the first cycle's rate held steady forever.
+        /// Useful for showing users the difference: "Actual yield: X vs. Peak estimate: Y"
+        /// </summary>
+        public static long CalculateNaiveTotal(int qtyPerCycle, int cycleTimeSeconds, int totalDurationSeconds)
+        {
+            if (qtyPerCycle <= 0 || cycleTimeSeconds <= 0 || totalDurationSeconds <= 0)
+                return 0;
+
+            int numCycles = totalDurationSeconds / cycleTimeSeconds;
+            if (numCycles <= 0) return 0;
+
+            // The first cycle yield represents the peak output rate
+            double barWidth = cycleTimeSeconds / 900.0;
+            int firstCycleYield = CalculateSingleCycleYield(qtyPerCycle, barWidth, 0);
+            return (long)firstCycleYield * numCycles;
+        }
+
+        /// <summary>
+        /// Core formula implementation for a single cycle.
+        /// Matches the official EVE client calculation exactly.
+        /// </summary>
+        private static int CalculateSingleCycleYield(int qtyPerCycle, double barWidth, int cycleIndex)
+        {
+            double t = (cycleIndex + 0.5) * barWidth;
+            double decayValue = qtyPerCycle / (1.0 + t * DecayFactor);
+            double phaseShift = Math.Pow(qtyPerCycle, 0.7);
+
+            double sinA = Math.Cos(phaseShift + t * (1.0 / 12.0));
+            double sinB = Math.Cos(phaseShift / 2.0 + t * 0.2);
+            double sinC = Math.Cos(t * 0.5);
+
+            double sinStuff = Math.Max((sinA + sinB + sinC) / 3.0, 0.0);
+            double barHeight = decayValue * (1.0 + NoiseFactor * sinStuff);
+
+            return (int)(barWidth * barHeight);
+        }
+    }
+}

--- a/src/EveLens.Common/Services/Planetary/PlanetarySchematic.cs
+++ b/src/EveLens.Common/Services/Planetary/PlanetarySchematic.cs
@@ -1,0 +1,90 @@
+// EveLens — Character Intelligence for EVE Online
+// Copyright © 2006-2021 EVEMon Development Team, © 2025-2026 Alia Collins
+// Built with Claude Code (Anthropic)
+// Licensed under GPL v2 — see LICENSE for details
+
+using System.Collections.Generic;
+
+namespace EveLens.Common.Services.Planetary
+{
+    /// <summary>
+    /// Represents a PI factory schematic — what inputs it needs and what it produces.
+    /// </summary>
+    public sealed class PlanetarySchematic
+    {
+        public int SchematicID { get; }
+        public string Name { get; }
+        public int CycleTimeSeconds { get; }
+        public IReadOnlyList<SchematicMaterial> Inputs { get; }
+        public SchematicMaterial Output { get; }
+        public ProductionTier Tier { get; }
+
+        public PlanetarySchematic(int id, string name, int cycleTime, SchematicMaterial[] inputs, SchematicMaterial output, ProductionTier tier)
+        {
+            SchematicID = id;
+            Name = name;
+            CycleTimeSeconds = cycleTime;
+            Inputs = inputs;
+            Output = output;
+            Tier = tier;
+        }
+
+        /// <summary>
+        /// Input demand per hour for a specific material type.
+        /// </summary>
+        public int GetInputDemandPerHour(int typeId)
+        {
+            int cyclesPerHour = 3600 / CycleTimeSeconds;
+            foreach (var input in Inputs)
+            {
+                if (input.TypeID == typeId)
+                    return input.Quantity * cyclesPerHour;
+            }
+            return 0;
+        }
+
+        /// <summary>
+        /// Output production per hour.
+        /// </summary>
+        public int GetOutputPerHour()
+        {
+            int cyclesPerHour = 3600 / CycleTimeSeconds;
+            return Output.Quantity * cyclesPerHour;
+        }
+    }
+
+    /// <summary>
+    /// A material input or output in a schematic.
+    /// </summary>
+    public sealed class SchematicMaterial
+    {
+        public int TypeID { get; }
+        public string TypeName { get; }
+        public int Quantity { get; }
+
+        public SchematicMaterial(int typeId, string typeName, int quantity)
+        {
+            TypeID = typeId;
+            TypeName = typeName;
+            Quantity = quantity;
+        }
+    }
+
+    /// <summary>
+    /// The production tier of a schematic (determines the factory type that runs it).
+    /// </summary>
+    public enum ProductionTier
+    {
+        /// <summary>P0 → P1: Basic Industry Facility (30min cycle, 3000 input → 20 output)</summary>
+        Basic,
+
+        /// <summary>P1 → P2: Advanced Industry Facility (1hr cycle, 40+40 input → 5 output)</summary>
+        Advanced,
+
+        /// <summary>P2 → P3: Advanced Industry Facility (1hr cycle, 10+10+... input → 3 output)</summary>
+        AdvancedP3,
+
+        /// <summary>P3 → P4: High-Tech Production Plant (1hr cycle, 6+6+40 input → 1 output)</summary>
+        HighTech
+    }
+}

--- a/src/EveLens.Common/Services/Planetary/PlanetarySchematicsProvider.cs
+++ b/src/EveLens.Common/Services/Planetary/PlanetarySchematicsProvider.cs
@@ -1,0 +1,388 @@
+// EveLens — Character Intelligence for EVE Online
+// Copyright © 2006-2021 EVEMon Development Team, © 2025-2026 Alia Collins
+// Built with Claude Code (Anthropic)
+// Licensed under GPL v2 — see LICENSE for details
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace EveLens.Common.Services.Planetary
+{
+    /// <summary>
+    /// Provides static lookup for PI factory schematics.
+    /// Data sourced from SDE planetSchematics.yaml (68 schematics across 4 production tiers).
+    /// </summary>
+    public static class PlanetarySchematicsProvider
+    {
+        private static readonly Dictionary<int, PlanetarySchematic> s_schematics = new();
+        private static readonly Dictionary<int, PlanetarySchematic> s_schematicsByOutputType = new();
+        private static bool s_loaded;
+
+        /// <summary>
+        /// Gets a schematic by its ID (as referenced in ESI pin data).
+        /// </summary>
+        public static PlanetarySchematic GetSchematic(int schematicId)
+        {
+            EnsureLoaded();
+            s_schematics.TryGetValue(schematicId, out var schematic);
+            return schematic;
+        }
+
+        /// <summary>
+        /// Gets the schematic that produces a given output type.
+        /// </summary>
+        public static PlanetarySchematic GetSchematicByOutputType(int outputTypeId)
+        {
+            EnsureLoaded();
+            s_schematicsByOutputType.TryGetValue(outputTypeId, out var schematic);
+            return schematic;
+        }
+
+        /// <summary>
+        /// Gets all schematics of a specific production tier.
+        /// </summary>
+        public static IEnumerable<PlanetarySchematic> GetSchematicsByTier(ProductionTier tier)
+        {
+            EnsureLoaded();
+            return s_schematics.Values.Where(s => s.Tier == tier);
+        }
+
+        /// <summary>
+        /// Gets all loaded schematics.
+        /// </summary>
+        public static IReadOnlyDictionary<int, PlanetarySchematic> All
+        {
+            get
+            {
+                EnsureLoaded();
+                return s_schematics;
+            }
+        }
+
+        /// <summary>
+        /// Determines the production tier from schematic characteristics.
+        /// </summary>
+        internal static ProductionTier InferTier(int cycleTime, int totalInputQuantity, int outputQuantity)
+        {
+            if (cycleTime == 1800 && totalInputQuantity == 3000 && outputQuantity == 20)
+                return ProductionTier.Basic;
+
+            if (outputQuantity == 5)
+                return ProductionTier.Advanced;
+
+            if (outputQuantity == 3)
+                return ProductionTier.AdvancedP3;
+
+            if (outputQuantity == 1)
+                return ProductionTier.HighTech;
+
+            // Fallback based on cycle time and quantities
+            if (cycleTime == 1800)
+                return ProductionTier.Basic;
+
+            return totalInputQuantity <= 20 ? ProductionTier.AdvancedP3 : ProductionTier.Advanced;
+        }
+
+        private static void EnsureLoaded()
+        {
+            if (s_loaded) return;
+            s_loaded = true;
+            RegisterAll();
+        }
+
+        private static void Register(int id, string name, int cycleTime, SchematicMaterial[] inputs, SchematicMaterial output, ProductionTier tier)
+        {
+            var schematic = new PlanetarySchematic(id, name, cycleTime, inputs, output, tier);
+            s_schematics[id] = schematic;
+            s_schematicsByOutputType[output.TypeID] = schematic;
+        }
+
+        private static void RegisterAll()
+        {
+            // ═══════════════════════════════════════════════════════════════
+            // P0 → P1: Basic Industry Facility (1800s cycle, 3000 in → 20 out)
+            // ═══════════════════════════════════════════════════════════════
+            Register(121, "Water", 1800,
+                new[] { new SchematicMaterial(2268, "Aqueous Liquids", 3000) },
+                new SchematicMaterial(3645, "Water", 20), ProductionTier.Basic);
+
+            Register(122, "Plasmoids", 1800,
+                new[] { new SchematicMaterial(2308, "Suspended Plasma", 3000) },
+                new SchematicMaterial(2389, "Plasmoids", 20), ProductionTier.Basic);
+
+            Register(123, "Electrolytes", 1800,
+                new[] { new SchematicMaterial(2309, "Ionic Solutions", 3000) },
+                new SchematicMaterial(2390, "Electrolytes", 20), ProductionTier.Basic);
+
+            Register(124, "Oxygen", 1800,
+                new[] { new SchematicMaterial(2310, "Noble Gas", 3000) },
+                new SchematicMaterial(3683, "Oxygen", 20), ProductionTier.Basic);
+
+            Register(125, "Oxidizing Compound", 1800,
+                new[] { new SchematicMaterial(2311, "Reactive Gas", 3000) },
+                new SchematicMaterial(2392, "Oxidizing Compound", 20), ProductionTier.Basic);
+
+            Register(126, "Reactive Metals", 1800,
+                new[] { new SchematicMaterial(2267, "Base Metals", 3000) },
+                new SchematicMaterial(2398, "Reactive Metals", 20), ProductionTier.Basic);
+
+            Register(127, "Precious Metals", 1800,
+                new[] { new SchematicMaterial(2270, "Noble Metals", 3000) },
+                new SchematicMaterial(2399, "Precious Metals", 20), ProductionTier.Basic);
+
+            Register(128, "Toxic Metals", 1800,
+                new[] { new SchematicMaterial(2272, "Heavy Metals", 3000) },
+                new SchematicMaterial(2400, "Toxic Metals", 20), ProductionTier.Basic);
+
+            Register(129, "Chiral Structures", 1800,
+                new[] { new SchematicMaterial(2306, "Non-CS Crystals", 3000) },
+                new SchematicMaterial(2401, "Chiral Structures", 20), ProductionTier.Basic);
+
+            Register(130, "Silicon", 1800,
+                new[] { new SchematicMaterial(2307, "Felsic Magma", 3000) },
+                new SchematicMaterial(9828, "Silicon", 20), ProductionTier.Basic);
+
+            Register(131, "Bacteria", 1800,
+                new[] { new SchematicMaterial(2073, "Micro Organisms", 3000) },
+                new SchematicMaterial(2393, "Bacteria", 20), ProductionTier.Basic);
+
+            Register(132, "Biomass", 1800,
+                new[] { new SchematicMaterial(2286, "Planktic Colonies", 3000) },
+                new SchematicMaterial(3779, "Biomass", 20), ProductionTier.Basic);
+
+            Register(133, "Proteins", 1800,
+                new[] { new SchematicMaterial(2287, "Complex Organisms", 3000) },
+                new SchematicMaterial(2395, "Proteins", 20), ProductionTier.Basic);
+
+            Register(134, "Biofuels", 1800,
+                new[] { new SchematicMaterial(2288, "Carbon Compounds", 3000) },
+                new SchematicMaterial(2396, "Biofuels", 20), ProductionTier.Basic);
+
+            Register(135, "Industrial Fibers", 1800,
+                new[] { new SchematicMaterial(2305, "Autotrophs", 3000) },
+                new SchematicMaterial(2397, "Industrial Fibers", 20), ProductionTier.Basic);
+
+            // ═══════════════════════════════════════════════════════════════
+            // P1 → P2: Advanced Industry Facility (3600s cycle, 40+40 in → 5 out)
+            // ═══════════════════════════════════════════════════════════════
+            Register(65, "Superconductors", 3600,
+                new[] { new SchematicMaterial(2389, "Plasmoids", 40), new SchematicMaterial(3645, "Water", 40) },
+                new SchematicMaterial(9838, "Superconductors", 5), ProductionTier.Advanced);
+
+            Register(66, "Coolant", 3600,
+                new[] { new SchematicMaterial(2390, "Electrolytes", 40), new SchematicMaterial(3645, "Water", 40) },
+                new SchematicMaterial(9832, "Coolant", 5), ProductionTier.Advanced);
+
+            Register(67, "Rocket Fuel", 3600,
+                new[] { new SchematicMaterial(2389, "Plasmoids", 40), new SchematicMaterial(2390, "Electrolytes", 40) },
+                new SchematicMaterial(9830, "Rocket Fuel", 5), ProductionTier.Advanced);
+
+            Register(68, "Synthetic Oil", 3600,
+                new[] { new SchematicMaterial(2390, "Electrolytes", 40), new SchematicMaterial(3683, "Oxygen", 40) },
+                new SchematicMaterial(3691, "Synthetic Oil", 5), ProductionTier.Advanced);
+
+            Register(69, "Oxides", 3600,
+                new[] { new SchematicMaterial(2392, "Oxidizing Compound", 40), new SchematicMaterial(3683, "Oxygen", 40) },
+                new SchematicMaterial(2317, "Oxides", 5), ProductionTier.Advanced);
+
+            Register(70, "Silicate Glass", 3600,
+                new[] { new SchematicMaterial(2392, "Oxidizing Compound", 40), new SchematicMaterial(9828, "Silicon", 40) },
+                new SchematicMaterial(3697, "Silicate Glass", 5), ProductionTier.Advanced);
+
+            Register(71, "Transmitter", 3600,
+                new[] { new SchematicMaterial(2389, "Plasmoids", 40), new SchematicMaterial(2401, "Chiral Structures", 40) },
+                new SchematicMaterial(9840, "Transmitter", 5), ProductionTier.Advanced);
+
+            Register(72, "Water-Cooled CPU", 3600,
+                new[] { new SchematicMaterial(2398, "Reactive Metals", 40), new SchematicMaterial(3645, "Water", 40) },
+                new SchematicMaterial(2328, "Water-Cooled CPU", 5), ProductionTier.Advanced);
+
+            Register(73, "Mechanical Parts", 3600,
+                new[] { new SchematicMaterial(2398, "Reactive Metals", 40), new SchematicMaterial(2399, "Precious Metals", 40) },
+                new SchematicMaterial(3689, "Mechanical Parts", 5), ProductionTier.Advanced);
+
+            Register(74, "Construction Blocks", 3600,
+                new[] { new SchematicMaterial(2398, "Reactive Metals", 40), new SchematicMaterial(2400, "Toxic Metals", 40) },
+                new SchematicMaterial(3828, "Construction Blocks", 5), ProductionTier.Advanced);
+
+            Register(75, "Enriched Uranium", 3600,
+                new[] { new SchematicMaterial(2399, "Precious Metals", 40), new SchematicMaterial(2400, "Toxic Metals", 40) },
+                new SchematicMaterial(44, "Enriched Uranium", 5), ProductionTier.Advanced);
+
+            Register(76, "Consumer Electronics", 3600,
+                new[] { new SchematicMaterial(2400, "Toxic Metals", 40), new SchematicMaterial(2401, "Chiral Structures", 40) },
+                new SchematicMaterial(9836, "Consumer Electronics", 5), ProductionTier.Advanced);
+
+            Register(77, "Miniature Electronics", 3600,
+                new[] { new SchematicMaterial(2401, "Chiral Structures", 40), new SchematicMaterial(9828, "Silicon", 40) },
+                new SchematicMaterial(9842, "Miniature Electronics", 5), ProductionTier.Advanced);
+
+            Register(78, "Nanites", 3600,
+                new[] { new SchematicMaterial(2393, "Bacteria", 40), new SchematicMaterial(2398, "Reactive Metals", 40) },
+                new SchematicMaterial(2463, "Nanites", 5), ProductionTier.Advanced);
+
+            Register(79, "Biocells", 3600,
+                new[] { new SchematicMaterial(2396, "Biofuels", 40), new SchematicMaterial(2399, "Precious Metals", 40) },
+                new SchematicMaterial(2329, "Biocells", 5), ProductionTier.Advanced);
+
+            Register(80, "Microfiber Shielding", 3600,
+                new[] { new SchematicMaterial(2397, "Industrial Fibers", 40), new SchematicMaterial(9828, "Silicon", 40) },
+                new SchematicMaterial(2327, "Microfiber Shielding", 5), ProductionTier.Advanced);
+
+            Register(81, "Viral Agent", 3600,
+                new[] { new SchematicMaterial(2393, "Bacteria", 40), new SchematicMaterial(3779, "Biomass", 40) },
+                new SchematicMaterial(3775, "Viral Agent", 5), ProductionTier.Advanced);
+
+            Register(82, "Fertilizer", 3600,
+                new[] { new SchematicMaterial(2393, "Bacteria", 40), new SchematicMaterial(2395, "Proteins", 40) },
+                new SchematicMaterial(3693, "Fertilizer", 5), ProductionTier.Advanced);
+
+            Register(83, "Genetically Enhanced Livestock", 3600,
+                new[] { new SchematicMaterial(2395, "Proteins", 40), new SchematicMaterial(3779, "Biomass", 40) },
+                new SchematicMaterial(15317, "Genetically Enhanced Livestock", 5), ProductionTier.Advanced);
+
+            Register(84, "Livestock", 3600,
+                new[] { new SchematicMaterial(2395, "Proteins", 40), new SchematicMaterial(2396, "Biofuels", 40) },
+                new SchematicMaterial(3725, "Livestock", 5), ProductionTier.Advanced);
+
+            Register(85, "Polytextiles", 3600,
+                new[] { new SchematicMaterial(2396, "Biofuels", 40), new SchematicMaterial(2397, "Industrial Fibers", 40) },
+                new SchematicMaterial(3695, "Polytextiles", 5), ProductionTier.Advanced);
+
+            Register(86, "Test Cultures", 3600,
+                new[] { new SchematicMaterial(2393, "Bacteria", 40), new SchematicMaterial(3645, "Water", 40) },
+                new SchematicMaterial(2319, "Test Cultures", 5), ProductionTier.Advanced);
+
+            Register(87, "Supertensile Plastics", 3600,
+                new[] { new SchematicMaterial(3683, "Oxygen", 40), new SchematicMaterial(3779, "Biomass", 40) },
+                new SchematicMaterial(2312, "Supertensile Plastics", 5), ProductionTier.Advanced);
+
+            Register(88, "Polyaramids", 3600,
+                new[] { new SchematicMaterial(2392, "Oxidizing Compound", 40), new SchematicMaterial(2397, "Industrial Fibers", 40) },
+                new SchematicMaterial(2321, "Polyaramids", 5), ProductionTier.Advanced);
+
+            // ═══════════════════════════════════════════════════════════════
+            // P2 → P3: Advanced Industry Facility (3600s cycle, 10+10(+10) in → 3 out)
+            // ═══════════════════════════════════════════════════════════════
+            Register(89, "Ukomi Superconductor", 3600,
+                new[] { new SchematicMaterial(3691, "Synthetic Oil", 10), new SchematicMaterial(9838, "Superconductors", 10) },
+                new SchematicMaterial(17136, "Ukomi Superconductor", 3), ProductionTier.AdvancedP3);
+
+            Register(90, "Condensates", 3600,
+                new[] { new SchematicMaterial(2317, "Oxides", 10), new SchematicMaterial(9832, "Coolant", 10) },
+                new SchematicMaterial(2344, "Condensates", 3), ProductionTier.AdvancedP3);
+
+            Register(91, "Camera Drones", 3600,
+                new[] { new SchematicMaterial(3697, "Silicate Glass", 10), new SchematicMaterial(9830, "Rocket Fuel", 10) },
+                new SchematicMaterial(2345, "Camera Drones", 3), ProductionTier.AdvancedP3);
+
+            Register(92, "Synthetic Synapses", 3600,
+                new[] { new SchematicMaterial(2312, "Supertensile Plastics", 10), new SchematicMaterial(2319, "Test Cultures", 10) },
+                new SchematicMaterial(2346, "Synthetic Synapses", 3), ProductionTier.AdvancedP3);
+
+            Register(94, "High-Tech Transmitter", 3600,
+                new[] { new SchematicMaterial(2321, "Polyaramids", 10), new SchematicMaterial(9840, "Transmitter", 10) },
+                new SchematicMaterial(17898, "High-Tech Transmitter", 3), ProductionTier.AdvancedP3);
+
+            Register(95, "Gel-Matrix Biopaste", 3600,
+                new[] { new SchematicMaterial(2317, "Oxides", 10), new SchematicMaterial(2329, "Biocells", 10), new SchematicMaterial(9838, "Superconductors", 10) },
+                new SchematicMaterial(2348, "Gel-Matrix Biopaste", 3), ProductionTier.AdvancedP3);
+
+            Register(96, "Supercomputers", 3600,
+                new[] { new SchematicMaterial(2328, "Water-Cooled CPU", 10), new SchematicMaterial(9832, "Coolant", 10), new SchematicMaterial(9836, "Consumer Electronics", 10) },
+                new SchematicMaterial(2349, "Supercomputers", 3), ProductionTier.AdvancedP3);
+
+            Register(97, "Robotics", 3600,
+                new[] { new SchematicMaterial(3689, "Mechanical Parts", 10), new SchematicMaterial(9836, "Consumer Electronics", 10) },
+                new SchematicMaterial(9848, "Robotics", 3), ProductionTier.AdvancedP3);
+
+            Register(98, "Smartfab Units", 3600,
+                new[] { new SchematicMaterial(3828, "Construction Blocks", 10), new SchematicMaterial(9842, "Miniature Electronics", 10) },
+                new SchematicMaterial(2351, "Smartfab Units", 3), ProductionTier.AdvancedP3);
+
+            Register(99, "Nuclear Reactors", 3600,
+                new[] { new SchematicMaterial(44, "Enriched Uranium", 10), new SchematicMaterial(2327, "Microfiber Shielding", 10) },
+                new SchematicMaterial(2352, "Nuclear Reactors", 3), ProductionTier.AdvancedP3);
+
+            Register(100, "Guidance Systems", 3600,
+                new[] { new SchematicMaterial(2328, "Water-Cooled CPU", 10), new SchematicMaterial(9840, "Transmitter", 10) },
+                new SchematicMaterial(9834, "Guidance Systems", 3), ProductionTier.AdvancedP3);
+
+            Register(102, "Neocoms", 3600,
+                new[] { new SchematicMaterial(2329, "Biocells", 10), new SchematicMaterial(3697, "Silicate Glass", 10) },
+                new SchematicMaterial(2354, "Neocoms", 3), ProductionTier.AdvancedP3);
+
+            Register(103, "Planetary Vehicles", 3600,
+                new[] { new SchematicMaterial(2312, "Supertensile Plastics", 10), new SchematicMaterial(3689, "Mechanical Parts", 10), new SchematicMaterial(9842, "Miniature Electronics", 10) },
+                new SchematicMaterial(9846, "Planetary Vehicles", 3), ProductionTier.AdvancedP3);
+
+            Register(104, "Biotech Research Reports", 3600,
+                new[] { new SchematicMaterial(2463, "Nanites", 10), new SchematicMaterial(3725, "Livestock", 10), new SchematicMaterial(3828, "Construction Blocks", 10) },
+                new SchematicMaterial(2358, "Biotech Research Reports", 3), ProductionTier.AdvancedP3);
+
+            Register(105, "Vaccines", 3600,
+                new[] { new SchematicMaterial(3725, "Livestock", 10), new SchematicMaterial(3775, "Viral Agent", 10) },
+                new SchematicMaterial(28974, "Vaccines", 3), ProductionTier.AdvancedP3);
+
+            Register(106, "Industrial Explosives", 3600,
+                new[] { new SchematicMaterial(3693, "Fertilizer", 10), new SchematicMaterial(3695, "Polytextiles", 10) },
+                new SchematicMaterial(2360, "Industrial Explosives", 3), ProductionTier.AdvancedP3);
+
+            Register(107, "Hermetic Membranes", 3600,
+                new[] { new SchematicMaterial(2321, "Polyaramids", 10), new SchematicMaterial(15317, "Genetically Enhanced Livestock", 10) },
+                new SchematicMaterial(2361, "Hermetic Membranes", 3), ProductionTier.AdvancedP3);
+
+            Register(108, "Transcranial Microcontroller", 3600,
+                new[] { new SchematicMaterial(2329, "Biocells", 10), new SchematicMaterial(2463, "Nanites", 10) },
+                new SchematicMaterial(12836, "Transcranial Microcontroller", 3), ProductionTier.AdvancedP3);
+
+            Register(109, "Data Chips", 3600,
+                new[] { new SchematicMaterial(2312, "Supertensile Plastics", 10), new SchematicMaterial(2327, "Microfiber Shielding", 10) },
+                new SchematicMaterial(17392, "Data Chips", 3), ProductionTier.AdvancedP3);
+
+            Register(110, "Hazmat Detection Systems", 3600,
+                new[] { new SchematicMaterial(3695, "Polytextiles", 10), new SchematicMaterial(3775, "Viral Agent", 10), new SchematicMaterial(9840, "Transmitter", 10) },
+                new SchematicMaterial(2366, "Hazmat Detection Systems", 3), ProductionTier.AdvancedP3);
+
+            Register(111, "Cryoprotectant Solution", 3600,
+                new[] { new SchematicMaterial(2319, "Test Cultures", 10), new SchematicMaterial(3691, "Synthetic Oil", 10), new SchematicMaterial(3693, "Fertilizer", 10) },
+                new SchematicMaterial(2367, "Cryoprotectant Solution", 3), ProductionTier.AdvancedP3);
+
+            // ═══════════════════════════════════════════════════════════════
+            // P3 → P4: High-Tech Production Plant (3600s cycle, 6+6+6(+40) in → 1 out)
+            // ═══════════════════════════════════════════════════════════════
+            Register(112, "Organic Mortar Applicators", 3600,
+                new[] { new SchematicMaterial(2344, "Condensates", 6), new SchematicMaterial(2393, "Bacteria", 40), new SchematicMaterial(9848, "Robotics", 6) },
+                new SchematicMaterial(2870, "Organic Mortar Applicators", 1), ProductionTier.HighTech);
+
+            Register(113, "Sterile Conduits", 3600,
+                new[] { new SchematicMaterial(2351, "Smartfab Units", 6), new SchematicMaterial(3645, "Water", 40), new SchematicMaterial(28974, "Vaccines", 6) },
+                new SchematicMaterial(2875, "Sterile Conduits", 1), ProductionTier.HighTech);
+
+            Register(114, "Nano-Factory", 3600,
+                new[] { new SchematicMaterial(2360, "Industrial Explosives", 6), new SchematicMaterial(2398, "Reactive Metals", 40), new SchematicMaterial(17136, "Ukomi Superconductor", 6) },
+                new SchematicMaterial(2869, "Nano-Factory", 1), ProductionTier.HighTech);
+
+            Register(115, "Self-Harmonizing Power Core", 3600,
+                new[] { new SchematicMaterial(2345, "Camera Drones", 6), new SchematicMaterial(2352, "Nuclear Reactors", 6), new SchematicMaterial(2361, "Hermetic Membranes", 6) },
+                new SchematicMaterial(2872, "Self-Harmonizing Power Core", 1), ProductionTier.HighTech);
+
+            Register(116, "Recursive Computing Module", 3600,
+                new[] { new SchematicMaterial(2346, "Synthetic Synapses", 6), new SchematicMaterial(9834, "Guidance Systems", 6), new SchematicMaterial(12836, "Transcranial Microcontroller", 6) },
+                new SchematicMaterial(2871, "Recursive Computing Module", 1), ProductionTier.HighTech);
+
+            Register(117, "Broadcast Node", 3600,
+                new[] { new SchematicMaterial(2354, "Neocoms", 6), new SchematicMaterial(17392, "Data Chips", 6), new SchematicMaterial(17898, "High-Tech Transmitter", 6) },
+                new SchematicMaterial(2867, "Broadcast Node", 1), ProductionTier.HighTech);
+
+            Register(118, "Integrity Response Drones", 3600,
+                new[] { new SchematicMaterial(2348, "Gel-Matrix Biopaste", 6), new SchematicMaterial(2366, "Hazmat Detection Systems", 6), new SchematicMaterial(9846, "Planetary Vehicles", 6) },
+                new SchematicMaterial(2868, "Integrity Response Drones", 1), ProductionTier.HighTech);
+
+            Register(119, "Wetware Mainframe", 3600,
+                new[] { new SchematicMaterial(2349, "Supercomputers", 6), new SchematicMaterial(2358, "Biotech Research Reports", 6), new SchematicMaterial(2367, "Cryoprotectant Solution", 6) },
+                new SchematicMaterial(2876, "Wetware Mainframe", 1), ProductionTier.HighTech);
+        }
+    }
+}

--- a/src/EveLens.Common/Services/Planetary/PlanetaryTaxCalculator.cs
+++ b/src/EveLens.Common/Services/Planetary/PlanetaryTaxCalculator.cs
@@ -1,0 +1,167 @@
+// EveLens — Character Intelligence for EVE Online
+// Copyright © 2006-2021 EVEMon Development Team, © 2025-2026 Alia Collins
+// Built with Claude Code (Anthropic)
+// Licensed under GPL v2 — see LICENSE for details
+
+using System;
+
+namespace EveLens.Common.Services.Planetary
+{
+    /// <summary>
+    /// Calculates PI export/import taxes based on system security, character skills,
+    /// and player-owned customs office (POCO) rates.
+    /// </summary>
+    public static class PlanetaryTaxCalculator
+    {
+        // NPC customs office base tax rates by security class
+        private const double NpcTaxRateHighSec = 0.10;  // 10%
+        private const double NpcTaxRateLowSec = 0.05;   // 5%
+        private const double NpcTaxRateNullSec = 0.0;   // 0% (null/WH)
+
+        // Customs Code Expertise reduces NPC tax by 10% per level (max 50% at level 5)
+        private const double SkillReductionPerLevel = 0.10;
+
+        // Default POCO tax rate when player hasn't configured one
+        public const double DefaultPocoTaxRate = 0.10;  // 10%
+
+        /// <summary>
+        /// Security class for PI tax calculation purposes.
+        /// Uses raw security value with 0.45 threshold (not the rounded display value).
+        /// </summary>
+        public enum SecurityClass
+        {
+            HighSec,
+            LowSec,
+            NullSec
+        }
+
+        /// <summary>
+        /// Determines the security class from a raw security status value.
+        /// PI mechanics use the raw value: >= 0.45 is highsec, > 0.0 is lowsec, <= 0.0 is nullsec.
+        /// This differs from the display rounding (which shows 0.5+ as highsec).
+        /// </summary>
+        public static SecurityClass GetSecurityClass(float securityStatus)
+        {
+            if (securityStatus >= 0.45f)
+                return SecurityClass.HighSec;
+            if (securityStatus > 0.0f)
+                return SecurityClass.LowSec;
+            return SecurityClass.NullSec;
+        }
+
+        /// <summary>
+        /// Gets the NPC base tax rate for a security class.
+        /// Only applies to NPC customs offices — player-owned have their own rates.
+        /// </summary>
+        public static double GetNpcBaseTaxRate(SecurityClass secClass)
+        {
+            return secClass switch
+            {
+                SecurityClass.HighSec => NpcTaxRateHighSec,
+                SecurityClass.LowSec => NpcTaxRateLowSec,
+                SecurityClass.NullSec => NpcTaxRateNullSec,
+                _ => NpcTaxRateHighSec
+            };
+        }
+
+        /// <summary>
+        /// Calculates the effective NPC tax rate after applying Customs Code Expertise skill.
+        /// The skill reduces the NPC portion by 10% per level (multiplicative).
+        /// </summary>
+        /// <param name="securityStatus">Raw system security status (-1.0 to 1.0)</param>
+        /// <param name="customsCodeExpertiseLevel">Skill level 0-5</param>
+        /// <returns>Effective NPC tax rate (0.0 to 0.10)</returns>
+        public static double GetEffectiveNpcTaxRate(float securityStatus, int customsCodeExpertiseLevel)
+        {
+            var secClass = GetSecurityClass(securityStatus);
+            double baseRate = GetNpcBaseTaxRate(secClass);
+            int skillLevel = Math.Clamp(customsCodeExpertiseLevel, 0, 5);
+            double reduction = 1.0 - (skillLevel * SkillReductionPerLevel);
+            return baseRate * reduction;
+        }
+
+        /// <summary>
+        /// Calculates the total effective tax rate (NPC + POCO combined).
+        /// In highsec, all COs are NPC-owned so POCO rate is zero.
+        /// In low/null, player POCOs replace NPC COs — the NPC rate still applies as base,
+        /// and the POCO owner sets an additional rate on top.
+        /// </summary>
+        /// <param name="securityStatus">Raw system security status</param>
+        /// <param name="customsCodeExpertiseLevel">CCE skill level 0-5</param>
+        /// <param name="pocoTaxRate">Player-configured POCO tax rate (0.0 to 1.0), null for NPC CO</param>
+        /// <returns>Total tax rate applied to exports</returns>
+        public static double GetTotalExportTaxRate(float securityStatus, int customsCodeExpertiseLevel, double? pocoTaxRate = null)
+        {
+            double npcRate = GetEffectiveNpcTaxRate(securityStatus, customsCodeExpertiseLevel);
+
+            if (pocoTaxRate.HasValue)
+                return npcRate + Math.Max(0, pocoTaxRate.Value);
+
+            return npcRate;
+        }
+
+        /// <summary>
+        /// Calculates the ISK cost to export a quantity of items from a planet.
+        /// Tax = BaseValue × Volume × TaxRate
+        /// BaseValue is the CCP-assigned base value for the item type (not market price).
+        /// </summary>
+        /// <param name="baseValue">CCP base value per unit (from SDE typeDogma/basePrice)</param>
+        /// <param name="quantity">Number of units to export</param>
+        /// <param name="taxRate">Total tax rate from GetTotalExportTaxRate()</param>
+        /// <returns>ISK cost of the export</returns>
+        public static double CalculateExportTax(double baseValue, int quantity, double taxRate)
+        {
+            if (baseValue <= 0 || quantity <= 0 || taxRate <= 0)
+                return 0;
+
+            return baseValue * quantity * taxRate;
+        }
+
+        /// <summary>
+        /// Calculates the ISK cost to import items to a planet.
+        /// Import tax uses the same formula as export but at half the rate.
+        /// </summary>
+        public static double CalculateImportTax(double baseValue, int quantity, double taxRate)
+        {
+            if (baseValue <= 0 || quantity <= 0 || taxRate <= 0)
+                return 0;
+
+            return baseValue * quantity * (taxRate * 0.5);
+        }
+
+        /// <summary>
+        /// Rounds a raw security status for display, implementing EVE's special rounding rule:
+        /// positive values in (0, 0.05] round UP to 0.1, never to 0.0.
+        /// </summary>
+        public static double RoundSecurityForDisplay(double securityStatus)
+        {
+            if (securityStatus == 0.0)
+                return 0.0;
+
+            if (securityStatus > 0.0 && securityStatus <= 0.05)
+                return 0.1;
+
+            return Math.Round(securityStatus, 1, MidpointRounding.AwayFromZero);
+        }
+
+        /// <summary>
+        /// Gets the EVE-standard color hex code for a security status value (rounded display).
+        /// </summary>
+        public static string GetSecurityColor(double securityStatus)
+        {
+            double rounded = RoundSecurityForDisplay(securityStatus);
+
+            if (rounded >= 1.0) return "#2C75E1";
+            if (rounded >= 0.9) return "#399AEB";
+            if (rounded >= 0.8) return "#4ECEF8";
+            if (rounded >= 0.7) return "#60DBA3";
+            if (rounded >= 0.6) return "#71E754";
+            if (rounded >= 0.5) return "#F5FF83";
+            if (rounded >= 0.4) return "#DC6C06";
+            if (rounded >= 0.3) return "#CE440F";
+            if (rounded >= 0.2) return "#BB1116";
+            if (rounded >= 0.1) return "#731F1F";
+            return "#8D3163";
+        }
+    }
+}

--- a/src/EveLens.Common/Services/Planetary/ProductionChainAnalyzer.cs
+++ b/src/EveLens.Common/Services/Planetary/ProductionChainAnalyzer.cs
@@ -37,13 +37,15 @@ namespace EveLens.Common.Services.Planetary
             var storage = ClassifyStorage(pins);
             var bottlenecks = DetectBottlenecks(extractors, factories, routes);
 
+            var alertMinutes = Settings.UI?.MainWindow?.Planetary?.AlertLeadTimeMinutes ?? 120;
+
             return new ColonyAnalysis(
                 colony,
                 extractors,
                 factories,
                 storage,
                 bottlenecks,
-                CalculateOverallHealth(extractors, bottlenecks));
+                CalculateOverallHealth(extractors, bottlenecks, alertMinutes));
         }
 
         private static List<ExtractorInfo> ClassifyExtractors(List<PlanetaryPin> pins)
@@ -237,7 +239,7 @@ namespace EveLens.Common.Services.Planetary
             return $"Type {typeId}";
         }
 
-        private static ColonyHealthStatus CalculateOverallHealth(List<ExtractorInfo> extractors, List<Bottleneck> bottlenecks)
+        private static ColonyHealthStatus CalculateOverallHealth(List<ExtractorInfo> extractors, List<Bottleneck> bottlenecks, int alertMinutes)
         {
             if (extractors.Count == 0)
                 return ColonyHealthStatus.NoExtractors;
@@ -250,7 +252,6 @@ namespace EveLens.Common.Services.Planetary
             if (anyIdle)
                 return ColonyHealthStatus.Idle;
 
-            var alertMinutes = Settings.UI?.MainWindow?.Planetary?.AlertLeadTimeMinutes ?? 120;
             var leadTime = TimeSpan.FromMinutes(alertMinutes);
             var now = DateTime.UtcNow;
             bool anyExpiringSoon = extractors.Any(e =>

--- a/src/EveLens.Common/Services/Planetary/ProductionChainAnalyzer.cs
+++ b/src/EveLens.Common/Services/Planetary/ProductionChainAnalyzer.cs
@@ -1,0 +1,406 @@
+// EveLens — Character Intelligence for EVE Online
+// Copyright © 2006-2021 EVEMon Development Team, © 2025-2026 Alia Collins
+// Built with Claude Code (Anthropic)
+// Licensed under GPL v2 — see LICENSE for details
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using EveLens.Common.Constants;
+using EveLens.Common.Models;
+
+namespace EveLens.Common.Services.Planetary
+{
+    /// <summary>
+    /// Analyzes a colony's production chain to identify structure, throughput, and bottlenecks.
+    /// Takes raw pin/route/link data and produces an actionable analysis.
+    /// </summary>
+    public static class ProductionChainAnalyzer
+    {
+        /// <summary>
+        /// Performs a full analysis of a colony's production chain.
+        /// </summary>
+        public static ColonyAnalysis Analyze(PlanetaryColony colony)
+        {
+            if (colony == null)
+                return ColonyAnalysis.Empty;
+
+            var pins = colony.Pins.ToList();
+            var routes = colony.Routes.ToList();
+            var links = colony.Links.ToList();
+
+            if (pins.Count == 0)
+                return ColonyAnalysis.Empty;
+
+            var extractors = ClassifyExtractors(pins);
+            var factories = ClassifyFactories(pins);
+            var storage = ClassifyStorage(pins);
+            var bottlenecks = DetectBottlenecks(extractors, factories, routes);
+
+            return new ColonyAnalysis(
+                colony,
+                extractors,
+                factories,
+                storage,
+                bottlenecks,
+                CalculateOverallHealth(extractors, bottlenecks));
+        }
+
+        private static List<ExtractorInfo> ClassifyExtractors(List<PlanetaryPin> pins)
+        {
+            var result = new List<ExtractorInfo>();
+
+            foreach (var pin in pins)
+            {
+                if (!DBConstants.EcuTypeIDs.Contains(pin.TypeID))
+                    continue;
+
+                int durationSeconds = 0;
+                if (pin.ExpiryTime > pin.InstallTime)
+                    durationSeconds = (int)(pin.ExpiryTime - pin.InstallTime).TotalSeconds;
+
+                var yields = pin.CycleTime > 0 && durationSeconds > 0
+                    ? ExtractionCalculator.CalculateCycleYields(pin.QuantityPerCycle, pin.CycleTime, durationSeconds)
+                    : Array.Empty<int>();
+
+                int currentCycleIndex = 0;
+                if (pin.InstallTime != DateTime.MinValue && pin.CycleTime > 0)
+                {
+                    var elapsed = (DateTime.UtcNow - pin.InstallTime).TotalSeconds;
+                    currentCycleIndex = Math.Min((int)(elapsed / pin.CycleTime), yields.Length - 1);
+                    if (currentCycleIndex < 0) currentCycleIndex = 0;
+                }
+
+                double currentYieldPerHour = yields.Length > 0 && currentCycleIndex < yields.Length
+                    ? ExtractionCalculator.CalculateYieldPerHourAtCycle(pin.QuantityPerCycle, pin.CycleTime, currentCycleIndex)
+                    : 0;
+
+                long totalYield = 0;
+                for (int i = 0; i < yields.Length; i++)
+                    totalYield += yields[i];
+
+                long remainingYield = 0;
+                for (int i = currentCycleIndex; i < yields.Length; i++)
+                    remainingYield += yields[i];
+
+                result.Add(new ExtractorInfo(
+                    pin,
+                    pin.ContentTypeID,
+                    pin.ContentTypeName,
+                    currentYieldPerHour,
+                    totalYield,
+                    remainingYield,
+                    durationSeconds > 0 ? durationSeconds : 0,
+                    currentCycleIndex,
+                    yields.Length));
+            }
+
+            return result;
+        }
+
+        private static List<FactoryInfo> ClassifyFactories(List<PlanetaryPin> pins)
+        {
+            var result = new List<FactoryInfo>();
+
+            foreach (var pin in pins)
+            {
+                if (pin.SchematicID <= 0)
+                    continue;
+                if (DBConstants.EcuTypeIDs.Contains(pin.TypeID))
+                    continue;
+
+                var schematic = PlanetarySchematicsProvider.GetSchematic((int)pin.SchematicID);
+                if (schematic == null)
+                    continue;
+
+                result.Add(new FactoryInfo(pin, schematic));
+            }
+
+            return result;
+        }
+
+        private static List<StorageInfo> ClassifyStorage(List<PlanetaryPin> pins)
+        {
+            var result = new List<StorageInfo>();
+            var storageGroupNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+            {
+                "Command Centers", "Spaceports", "Storage Facilities"
+            };
+
+            foreach (var pin in pins)
+            {
+                if (DBConstants.EcuTypeIDs.Contains(pin.TypeID))
+                    continue;
+                if (pin.SchematicID > 0)
+                    continue;
+                if (storageGroupNames.Contains(pin.GroupName ?? ""))
+                    result.Add(new StorageInfo(pin));
+            }
+
+            return result;
+        }
+
+        private static List<Bottleneck> DetectBottlenecks(
+            List<ExtractorInfo> extractors,
+            List<FactoryInfo> factories,
+            List<PlanetaryRoute> routes)
+        {
+            var bottlenecks = new List<Bottleneck>();
+
+            // Group factories by their input material type to calculate total demand
+            var demandByType = new Dictionary<int, double>();
+            foreach (var factory in factories)
+            {
+                foreach (var input in factory.Schematic.Inputs)
+                {
+                    int demandPerHour = factory.Schematic.GetInputDemandPerHour(input.TypeID);
+                    if (!demandByType.ContainsKey(input.TypeID))
+                        demandByType[input.TypeID] = 0;
+                    demandByType[input.TypeID] += demandPerHour;
+                }
+            }
+
+            // Check if extractors can meet factory demand for P0 materials
+            var supplyByType = new Dictionary<int, double>();
+            foreach (var extractor in extractors)
+            {
+                if (extractor.OutputTypeID <= 0) continue;
+                if (!supplyByType.ContainsKey(extractor.OutputTypeID))
+                    supplyByType[extractor.OutputTypeID] = 0;
+                supplyByType[extractor.OutputTypeID] += extractor.CurrentYieldPerHour;
+            }
+
+            // Also check factory outputs as supply for downstream factories
+            foreach (var factory in factories)
+            {
+                int outputPerHour = factory.Schematic.GetOutputPerHour();
+                int outputType = factory.Schematic.Output.TypeID;
+                if (!supplyByType.ContainsKey(outputType))
+                    supplyByType[outputType] = 0;
+                supplyByType[outputType] += outputPerHour;
+            }
+
+            // Detect mismatches
+            foreach (var kvp in demandByType)
+            {
+                int typeId = kvp.Key;
+                double demand = kvp.Value;
+                supplyByType.TryGetValue(typeId, out double supply);
+
+                if (supply <= 0 && demand > 0)
+                {
+                    bottlenecks.Add(new Bottleneck(
+                        typeId,
+                        GetTypeName(typeId, factories, extractors),
+                        supply,
+                        demand,
+                        BottleneckSeverity.Critical));
+                }
+                else if (supply < demand * 0.8)
+                {
+                    bottlenecks.Add(new Bottleneck(
+                        typeId,
+                        GetTypeName(typeId, factories, extractors),
+                        supply,
+                        demand,
+                        BottleneckSeverity.Starving));
+                }
+                else if (supply > demand * 1.5)
+                {
+                    bottlenecks.Add(new Bottleneck(
+                        typeId,
+                        GetTypeName(typeId, factories, extractors),
+                        supply,
+                        demand,
+                        BottleneckSeverity.Overflow));
+                }
+            }
+
+            return bottlenecks;
+        }
+
+        private static string GetTypeName(int typeId, List<FactoryInfo> factories, List<ExtractorInfo> extractors)
+        {
+            foreach (var ext in extractors)
+                if (ext.OutputTypeID == typeId)
+                    return ext.OutputTypeName;
+
+            foreach (var fac in factories)
+            {
+                if (fac.Schematic.Output.TypeID == typeId)
+                    return fac.Schematic.Output.TypeName;
+                foreach (var input in fac.Schematic.Inputs)
+                    if (input.TypeID == typeId)
+                        return input.TypeName;
+            }
+
+            return $"Type {typeId}";
+        }
+
+        private static ColonyHealthStatus CalculateOverallHealth(List<ExtractorInfo> extractors, List<Bottleneck> bottlenecks)
+        {
+            if (extractors.Count == 0)
+                return ColonyHealthStatus.NoExtractors;
+
+            bool allIdle = extractors.All(e => e.Pin.State == Enumerations.PlanetaryPinState.Idle);
+            if (allIdle)
+                return ColonyHealthStatus.Idle;
+
+            bool anyIdle = extractors.Any(e => e.Pin.State == Enumerations.PlanetaryPinState.Idle);
+            if (anyIdle)
+                return ColonyHealthStatus.Idle;
+
+            var alertMinutes = Settings.UI?.MainWindow?.Planetary?.AlertLeadTimeMinutes ?? 120;
+            var leadTime = TimeSpan.FromMinutes(alertMinutes);
+            var now = DateTime.UtcNow;
+            bool anyExpiringSoon = extractors.Any(e =>
+                e.Pin.ExpiryTime > now && (e.Pin.ExpiryTime - now) <= leadTime);
+
+            if (anyExpiringSoon)
+                return ColonyHealthStatus.Expiring;
+
+            return ColonyHealthStatus.Optimal;
+        }
+    }
+
+    #region Analysis Result Types
+
+    public sealed class ColonyAnalysis
+    {
+        public static readonly ColonyAnalysis Empty = new(null, new(), new(), new(), new(), ColonyHealthStatus.NoExtractors);
+
+        public PlanetaryColony Colony { get; }
+        public IReadOnlyList<ExtractorInfo> Extractors { get; }
+        public IReadOnlyList<FactoryInfo> Factories { get; }
+        public IReadOnlyList<StorageInfo> Storage { get; }
+        public IReadOnlyList<Bottleneck> Bottlenecks { get; }
+        public ColonyHealthStatus Health { get; }
+
+        public TimeSpan TimeUntilFirstIdle
+        {
+            get
+            {
+                var earliest = DateTime.MaxValue;
+                foreach (var ext in Extractors)
+                {
+                    if (ext.Pin.ExpiryTime > DateTime.UtcNow && ext.Pin.ExpiryTime < earliest)
+                        earliest = ext.Pin.ExpiryTime;
+                }
+                return earliest == DateTime.MaxValue ? TimeSpan.Zero : earliest - DateTime.UtcNow;
+            }
+        }
+
+        public int TotalExtractorCount => Extractors.Count;
+        public int ActiveExtractorCount => Extractors.Count(e => e.Pin.State == Enumerations.PlanetaryPinState.Extracting);
+        public int FactoryCount => Factories.Count;
+        public bool HasYieldData => Extractors.Any(e => e.CurrentYieldPerHour > 0);
+
+        internal ColonyAnalysis(PlanetaryColony colony, List<ExtractorInfo> extractors,
+            List<FactoryInfo> factories, List<StorageInfo> storage,
+            List<Bottleneck> bottlenecks, ColonyHealthStatus health)
+        {
+            Colony = colony;
+            Extractors = extractors;
+            Factories = factories;
+            Storage = storage;
+            Bottlenecks = bottlenecks;
+            Health = health;
+        }
+    }
+
+    public sealed class ExtractorInfo
+    {
+        public PlanetaryPin Pin { get; }
+        public int OutputTypeID { get; }
+        public string OutputTypeName { get; }
+        public double CurrentYieldPerHour { get; }
+        public long TotalProgramYield { get; }
+        public long RemainingYield { get; }
+        public int TotalDurationSeconds { get; }
+        public int CurrentCycleIndex { get; }
+        public int TotalCycles { get; }
+        public double PercentComplete => TotalCycles > 0 ? (double)CurrentCycleIndex / TotalCycles : 0;
+
+        internal ExtractorInfo(PlanetaryPin pin, int outputTypeId, string outputTypeName,
+            double currentYieldPerHour, long totalYield, long remainingYield,
+            int totalDuration, int currentCycle, int totalCycles)
+        {
+            Pin = pin;
+            OutputTypeID = outputTypeId;
+            OutputTypeName = outputTypeName;
+            CurrentYieldPerHour = currentYieldPerHour;
+            TotalProgramYield = totalYield;
+            RemainingYield = remainingYield;
+            TotalDurationSeconds = totalDuration;
+            CurrentCycleIndex = currentCycle;
+            TotalCycles = totalCycles;
+        }
+    }
+
+    public sealed class FactoryInfo
+    {
+        public PlanetaryPin Pin { get; }
+        public PlanetarySchematic Schematic { get; }
+        public int OutputPerHour => Schematic.GetOutputPerHour();
+        public string OutputName => Schematic.Output.TypeName;
+        public ProductionTier Tier => Schematic.Tier;
+
+        internal FactoryInfo(PlanetaryPin pin, PlanetarySchematic schematic)
+        {
+            Pin = pin;
+            Schematic = schematic;
+        }
+    }
+
+    public sealed class StorageInfo
+    {
+        public PlanetaryPin Pin { get; }
+        public string TypeName => Pin.TypeName;
+        public int ContentQuantity => Pin.ContentQuantity;
+        public double ContentVolume => Pin.ContentVolume;
+
+        internal StorageInfo(PlanetaryPin pin)
+        {
+            Pin = pin;
+        }
+    }
+
+    public sealed class Bottleneck
+    {
+        public int MaterialTypeID { get; }
+        public string MaterialName { get; }
+        public double SupplyPerHour { get; }
+        public double DemandPerHour { get; }
+        public BottleneckSeverity Severity { get; }
+        public double Efficiency => DemandPerHour > 0 ? Math.Min(SupplyPerHour / DemandPerHour, 2.0) : 0;
+        public double DeficitPerHour => Math.Max(0, DemandPerHour - SupplyPerHour);
+        public double SurplusPerHour => Math.Max(0, SupplyPerHour - DemandPerHour);
+
+        internal Bottleneck(int typeId, string name, double supply, double demand, BottleneckSeverity severity)
+        {
+            MaterialTypeID = typeId;
+            MaterialName = name;
+            SupplyPerHour = supply;
+            DemandPerHour = demand;
+            Severity = severity;
+        }
+    }
+
+    public enum BottleneckSeverity
+    {
+        Optimal,
+        Overflow,
+        Starving,
+        Critical
+    }
+
+    public enum ColonyHealthStatus
+    {
+        Optimal,
+        Expiring,
+        Idle,
+        NoExtractors
+    }
+
+    #endregion
+}

--- a/src/EveLens.Common/Settings.cs
+++ b/src/EveLens.Common/Settings.cs
@@ -176,6 +176,12 @@ namespace EveLens.Common
         /// </summary>
         public static IList<CharacterGroupSettings> CharacterGroups { get; private set; } = new List<CharacterGroupSettings>();
 
+        /// <summary>
+        /// Gets or sets the display order of ungrouped characters on the overview.
+        /// Characters not in this list appear after those that are, in their natural order.
+        /// </summary>
+        public static List<Guid> UngroupedCharacterOrder { get; set; } = new List<Guid>();
+
         public static IList<GlobalPlanTemplate> GlobalPlanTemplates { get; set; } = new List<GlobalPlanTemplate>();
 
         #endregion
@@ -228,6 +234,9 @@ namespace EveLens.Common
 
                 // Character groups
                 CharacterGroups = new List<CharacterGroupSettings>(s_settings.CharacterGroups);
+
+                // Ungrouped character order
+                UngroupedCharacterOrder = new List<Guid>(s_settings.UngroupedCharacterOrder ?? new List<Guid>());
 
                 // Global plan templates
                 GlobalPlanTemplates = new List<GlobalPlanTemplate>(s_settings.GlobalPlanTemplates);

--- a/src/EveLens.Common/SettingsIO.cs
+++ b/src/EveLens.Common/SettingsIO.cs
@@ -238,6 +238,8 @@ namespace EveLens.Common
             foreach (var group in CharacterGroups)
                 serial.CharacterGroups.Add(group);
 
+            serial.UngroupedCharacterOrder = new List<Guid>(UngroupedCharacterOrder);
+
             foreach (var template in GlobalPlanTemplates)
                 serial.GlobalPlanTemplates.Add(template);
 

--- a/src/EveLens.Common/SettingsObjects/PlanetarySettings.cs
+++ b/src/EveLens.Common/SettingsObjects/PlanetarySettings.cs
@@ -60,6 +60,19 @@ namespace EveLens.Common.SettingsObjects
         public bool ShowEcuOnly { get; set; }
 
         /// <summary>
+        /// Gets or sets the alert lead time in minutes before an extractor expires.
+        /// Set to 0 to disable pre-expiry alerts. Default: 120 (2 hours).
+        /// </summary>
+        [XmlElement("alertLeadTimeMinutes")]
+        public int AlertLeadTimeMinutes { get; set; } = 120;
+
+        /// <summary>
+        /// Gets or sets whether pre-expiry alerts are enabled.
+        /// </summary>
+        [XmlElement("alertsEnabled")]
+        public bool AlertsEnabled { get; set; } = true;
+
+        /// <summary>
         /// Gets the default columns.
         /// </summary>
         /// <value>The default columns.</value>

--- a/src/EveLens.Common/ViewModels/PlanOptimizerViewModel.cs
+++ b/src/EveLens.Common/ViewModels/PlanOptimizerViewModel.cs
@@ -53,8 +53,8 @@ namespace EveLens.Common.ViewModels
     {
         private static readonly EveAttribute[] AllAttributes =
         {
-            EveAttribute.Intelligence, EveAttribute.Perception,
-            EveAttribute.Charisma, EveAttribute.Willpower, EveAttribute.Memory
+            EveAttribute.Perception, EveAttribute.Memory,
+            EveAttribute.Willpower, EveAttribute.Intelligence, EveAttribute.Charisma
         };
 
         private Dictionary<EveAttribute, int> _currentAttributes = new();

--- a/src/EveLens.Common/ViewModels/PlanetaryDashboardViewModel.cs
+++ b/src/EveLens.Common/ViewModels/PlanetaryDashboardViewModel.cs
@@ -1,0 +1,259 @@
+// EveLens — Character Intelligence for EVE Online
+// Copyright © 2006-2021 EVEMon Development Team, © 2025-2026 Alia Collins
+// Built with Claude Code (Anthropic)
+// Licensed under GPL v2 — see LICENSE for details
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using EveLens.Common.Data;
+using EveLens.Common.Events;
+using EveLens.Common.Models;
+using EveLens.Common.Services.Planetary;
+using EveLens.Core.Interfaces;
+
+namespace EveLens.Common.ViewModels
+{
+    public sealed class PlanetaryDashboardViewModel : CharacterViewModelBase
+    {
+        private List<ColonyCardData> _colonies = new();
+        private string _textFilter = string.Empty;
+        private double _totalNetIskPerDay;
+        private int _totalColonies;
+        private int _idleColonies;
+        private int _expiringColonies;
+        private bool _hasAnyEconomicsData;
+        private int _customsCodeExpertiseLevel;
+
+        public PlanetaryDashboardViewModel(IEventAggregator eventAggregator, IDispatcher? dispatcher = null)
+            : base(eventAggregator, dispatcher)
+        {
+            SubscribeForCharacter<CharacterPlanetaryColoniesUpdatedEvent>(e => Refresh());
+            SubscribeForCharacter<CharacterPlanetaryLayoutUpdatedEvent>(e => Refresh());
+        }
+
+        public PlanetaryDashboardViewModel() : base()
+        {
+            SubscribeForCharacter<CharacterPlanetaryColoniesUpdatedEvent>(e => Refresh());
+            SubscribeForCharacter<CharacterPlanetaryLayoutUpdatedEvent>(e => Refresh());
+        }
+
+        public IReadOnlyList<ColonyCardData> Colonies => _colonies;
+
+        public string TextFilter
+        {
+            get => _textFilter;
+            set
+            {
+                if (SetProperty(ref _textFilter, value))
+                    Refresh();
+            }
+        }
+
+        public double TotalNetIskPerDay
+        {
+            get => _totalNetIskPerDay;
+            private set => SetProperty(ref _totalNetIskPerDay, value);
+        }
+
+        public int TotalColonies
+        {
+            get => _totalColonies;
+            private set => SetProperty(ref _totalColonies, value);
+        }
+
+        public int IdleColonies
+        {
+            get => _idleColonies;
+            private set => SetProperty(ref _idleColonies, value);
+        }
+
+        public int ExpiringColonies
+        {
+            get => _expiringColonies;
+            private set => SetProperty(ref _expiringColonies, value);
+        }
+
+        public bool HasAnyEconomicsData
+        {
+            get => _hasAnyEconomicsData;
+            private set => SetProperty(ref _hasAnyEconomicsData, value);
+        }
+
+        protected override void OnCharacterChanged()
+        {
+            base.OnCharacterChanged();
+            UpdateSkillLevel();
+            Refresh();
+        }
+
+        public void Refresh()
+        {
+            if (Character is not CCPCharacter ccp)
+            {
+                _colonies = new List<ColonyCardData>();
+                OnPropertyChanged(nameof(Colonies));
+                return;
+            }
+
+            var economicsService = new ColonyEconomicsService(_customsCodeExpertiseLevel);
+            var cards = new List<ColonyCardData>();
+
+            foreach (var colony in ccp.PlanetaryColonies)
+            {
+                var analysis = ProductionChainAnalyzer.Analyze(colony);
+                var economics = economicsService.Calculate(analysis);
+
+                var card = new ColonyCardData(colony, analysis, economics);
+
+                if (!string.IsNullOrWhiteSpace(_textFilter))
+                {
+                    bool match = card.PlanetName.Contains(_textFilter, StringComparison.OrdinalIgnoreCase) ||
+                                 card.PlanetTypeName.Contains(_textFilter, StringComparison.OrdinalIgnoreCase) ||
+                                 card.SystemName.Contains(_textFilter, StringComparison.OrdinalIgnoreCase) ||
+                                 card.OutputName.Contains(_textFilter, StringComparison.OrdinalIgnoreCase);
+                    if (!match) continue;
+                }
+
+                cards.Add(card);
+            }
+
+            cards.Sort((a, b) =>
+            {
+                int healthCompare = GetHealthSortOrder(a.Health).CompareTo(GetHealthSortOrder(b.Health));
+                if (healthCompare != 0) return healthCompare;
+                return a.TimeUntilIdle.CompareTo(b.TimeUntilIdle);
+            });
+
+            _colonies = cards;
+            TotalColonies = cards.Count;
+            IdleColonies = cards.Count(c => c.Health == ColonyHealthStatus.Idle);
+            ExpiringColonies = cards.Count(c => c.Health == ColonyHealthStatus.Expiring);
+            TotalNetIskPerDay = cards.Where(c => c.HasYieldData).Sum(c => c.NetIskPerDay);
+            HasAnyEconomicsData = cards.Any(c => c.HasYieldData);
+            OnPropertyChanged(nameof(Colonies));
+        }
+
+        private void UpdateSkillLevel()
+        {
+            _customsCodeExpertiseLevel = 0;
+
+            if (Character == null) return;
+
+            var skill = StaticSkills.GetSkillByName("Customs Code Expertise");
+            if (skill != null)
+                _customsCodeExpertiseLevel = (int)Character.GetSkillLevel(skill);
+        }
+
+        private static int GetHealthSortOrder(ColonyHealthStatus status)
+        {
+            return status switch
+            {
+                ColonyHealthStatus.Idle => 0,
+                ColonyHealthStatus.Expiring => 1,
+                ColonyHealthStatus.Optimal => 2,
+                ColonyHealthStatus.NoExtractors => 3,
+                _ => 99
+            };
+        }
+    }
+
+    public sealed class ColonyCardData
+    {
+        public PlanetaryColony Colony { get; }
+        public ColonyAnalysis Analysis { get; }
+        public ColonyEconomics Economics { get; }
+
+        public string PlanetName => Colony.PlanetName;
+        public string PlanetTypeName => Colony.PlanetTypeName;
+        public string SystemName => Colony.SolarSystem?.Name ?? "Unknown";
+        public float SecurityStatus => Colony.SolarSystem?.SecurityLevel ?? 0f;
+        public string SecurityDisplay => PlanetaryTaxCalculator.RoundSecurityForDisplay(SecurityStatus).ToString("0.0");
+        public string SecurityColor => PlanetaryTaxCalculator.GetSecurityColor(SecurityStatus);
+        public ColonyHealthStatus Health => Analysis.Health;
+        public TimeSpan TimeUntilIdle => Analysis.TimeUntilFirstIdle;
+        public int ActiveExtractors => Analysis.ActiveExtractorCount;
+        public int TotalExtractors => Analysis.TotalExtractorCount;
+        public int FactoryCount => Analysis.FactoryCount;
+
+        public double ExtractionProgress
+        {
+            get
+            {
+                if (Analysis.Extractors.Count == 0) return 0;
+                return Analysis.Extractors.Average(e => e.PercentComplete);
+            }
+        }
+
+        public double GrossIskPerDay => Economics.GrossIskPerDay;
+        public double TaxCostPerDay => Economics.TaxCostPerDay;
+        public double NetIskPerDay => Economics.NetIskPerDay;
+        public double TaxRate => Economics.TaxRate;
+
+        public string OutputName
+        {
+            get
+            {
+                if (Economics.Outputs.Count == 0) return "No output";
+                return Economics.Outputs[0].TypeName;
+            }
+        }
+
+        public ProductionTier OutputTier
+        {
+            get
+            {
+                if (Economics.Outputs.Count == 0) return ProductionTier.Basic;
+                return Economics.Outputs[0].Tier;
+            }
+        }
+
+        public string OutputTierLabel => OutputTier switch
+        {
+            ProductionTier.Basic => "P1",
+            ProductionTier.Advanced => "P2",
+            ProductionTier.AdvancedP3 => "P3",
+            ProductionTier.HighTech => "P4",
+            _ => "P0"
+        };
+
+        public bool HasYieldData => Analysis.HasYieldData;
+
+        public string TimeRemainingDisplay
+        {
+            get
+            {
+                if (Health == ColonyHealthStatus.Idle)
+                    return "IDLE";
+                if (Health == ColonyHealthStatus.NoExtractors)
+                    return "Factories only";
+                if (TimeUntilIdle <= TimeSpan.Zero)
+                    return "Expired";
+
+                if (TimeUntilIdle.TotalDays >= 1)
+                    return $"{(int)TimeUntilIdle.TotalDays}d {TimeUntilIdle.Hours}h";
+                if (TimeUntilIdle.TotalHours >= 1)
+                    return $"{(int)TimeUntilIdle.TotalHours}h {TimeUntilIdle.Minutes}m";
+                return $"{TimeUntilIdle.Minutes}m";
+            }
+        }
+
+        public string HealthLabel => Health switch
+        {
+            ColonyHealthStatus.Optimal => "Running",
+            ColonyHealthStatus.Expiring => "Expiring Soon",
+            ColonyHealthStatus.Idle => "Idle",
+            ColonyHealthStatus.NoExtractors => "Factories Only",
+            _ => ""
+        };
+
+        public IReadOnlyList<Bottleneck> Bottlenecks => Analysis.Bottlenecks;
+
+        internal ColonyCardData(PlanetaryColony colony, ColonyAnalysis analysis, ColonyEconomics economics)
+        {
+            Colony = colony;
+            Analysis = analysis;
+            Economics = economics;
+        }
+    }
+}

--- a/src/EveLens.Common/ViewModels/PlanetaryOverviewViewModel.cs
+++ b/src/EveLens.Common/ViewModels/PlanetaryOverviewViewModel.cs
@@ -1,0 +1,196 @@
+// EveLens — Character Intelligence for EVE Online
+// Copyright © 2006-2021 EVEMon Development Team, © 2025-2026 Alia Collins
+// Built with Claude Code (Anthropic)
+// Licensed under GPL v2 — see LICENSE for details
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using EveLens.Common.Data;
+using EveLens.Common.Models;
+using EveLens.Common.Services;
+using EveLens.Common.Services.Planetary;
+
+namespace EveLens.Common.ViewModels
+{
+    /// <summary>
+    /// ViewModel for the global Planetary Dashboard window — shows all characters' PI at a glance.
+    /// </summary>
+    public sealed class PlanetaryOverviewViewModel : ViewModelBase
+    {
+        private List<PlanetaryCharacterEntry> _entries = new();
+
+        public IReadOnlyList<PlanetaryCharacterEntry> Entries => _entries;
+
+        public int TotalCharacters => _entries.Count;
+        public int TotalColonies => _entries.Sum(e => e.ColonyCount);
+        public int IdleExtractors => _entries.Sum(e => e.IdleExtractorCount);
+        public int ActiveExtractors => _entries.Sum(e => e.ActiveExtractorCount);
+        public double TotalNetIskPerDay => _entries.Where(e => e.HasYieldData).Sum(e => e.NetIskPerDay);
+        public bool HasAnyEconomicsData => _entries.Any(e => e.HasYieldData);
+        public int CharactersNeedingAttention => _entries.Count(e => e.NeedsAttention);
+        public int ExpiringCount => _entries.Sum(e => e.ExpiringExtractorCount);
+
+        public void Refresh()
+        {
+            var entries = new List<PlanetaryCharacterEntry>();
+
+            foreach (var character in AppServices.Characters.Where(c => c.Monitored))
+            {
+                if (character is not CCPCharacter ccp)
+                    continue;
+
+                var colonies = ccp.PlanetaryColonies.ToList();
+                if (colonies.Count == 0)
+                    continue;
+
+                int cceLevel = 0;
+                var cceSkill = StaticSkills.GetSkillByName("Customs Code Expertise");
+                if (cceSkill != null)
+                    cceLevel = (int)character.GetSkillLevel(cceSkill);
+
+                var economicsService = new ColonyEconomicsService(cceLevel);
+                var colonyAnalyses = new List<(ColonyAnalysis analysis, ColonyEconomics economics)>();
+
+                foreach (var colony in colonies)
+                {
+                    var analysis = ProductionChainAnalyzer.Analyze(colony);
+                    var economics = economicsService.Calculate(analysis);
+                    colonyAnalyses.Add((analysis, economics));
+                }
+
+                var entry = new PlanetaryCharacterEntry(
+                    character,
+                    colonies.Count,
+                    colonyAnalyses);
+
+                entries.Add(entry);
+            }
+
+            entries.Sort((a, b) =>
+            {
+                int attentionCompare = b.NeedsAttention.CompareTo(a.NeedsAttention);
+                if (attentionCompare != 0) return attentionCompare;
+                int idleCompare = b.IdleExtractorCount.CompareTo(a.IdleExtractorCount);
+                if (idleCompare != 0) return idleCompare;
+                return a.TimeUntilFirstIdle.CompareTo(b.TimeUntilFirstIdle);
+            });
+
+            _entries = entries;
+        }
+    }
+
+    public sealed class PlanetaryCharacterEntry
+    {
+        public Character Character { get; }
+        public long CharacterID => Character.CharacterID;
+        public string CharacterName => Character.Name;
+        public int ColonyCount { get; }
+        public int ActiveExtractorCount { get; }
+        public int IdleExtractorCount { get; }
+        public int ExpiringExtractorCount { get; }
+        public int TotalExtractorCount { get; }
+        public int FactoryCount { get; }
+        public double GrossIskPerDay { get; }
+        public double TaxCostPerDay { get; }
+        public double NetIskPerDay { get; }
+        public bool HasYieldData { get; }
+        public TimeSpan TimeUntilFirstIdle { get; }
+        public ColonyHealthStatus WorstHealth { get; }
+        public bool NeedsAttention { get; }
+
+        public string TimeDisplay
+        {
+            get
+            {
+                if (IdleExtractorCount == TotalExtractorCount && TotalExtractorCount > 0)
+                    return "ALL IDLE";
+                if (TimeUntilFirstIdle <= TimeSpan.Zero && TotalExtractorCount > 0)
+                    return "Expired";
+                if (TimeUntilFirstIdle.TotalDays >= 1)
+                    return $"{(int)TimeUntilFirstIdle.TotalDays}d {TimeUntilFirstIdle.Hours}h";
+                if (TimeUntilFirstIdle.TotalHours >= 1)
+                    return $"{(int)TimeUntilFirstIdle.TotalHours}h {TimeUntilFirstIdle.Minutes}m";
+                if (TimeUntilFirstIdle > TimeSpan.Zero)
+                    return $"{TimeUntilFirstIdle.Minutes}m";
+                return "--";
+            }
+        }
+
+        public string HealthDisplay => WorstHealth switch
+        {
+            ColonyHealthStatus.Optimal => "Running",
+            ColonyHealthStatus.Expiring => "Expiring",
+            ColonyHealthStatus.Idle => "IDLE",
+            ColonyHealthStatus.NoExtractors => "Factories",
+            _ => ""
+        };
+
+        internal PlanetaryCharacterEntry(Character character, int colonyCount,
+            List<(ColonyAnalysis analysis, ColonyEconomics economics)> analyses)
+        {
+            Character = character;
+            ColonyCount = colonyCount;
+
+            int active = 0, idle = 0, expiring = 0, total = 0, factories = 0;
+            double grossIsk = 0, taxIsk = 0;
+            bool hasYield = false;
+            var earliestIdle = TimeSpan.MaxValue;
+            var worstHealth = ColonyHealthStatus.Optimal;
+
+            var alertMinutes = Settings.UI?.MainWindow?.Planetary?.AlertLeadTimeMinutes ?? 120;
+            var leadTime = TimeSpan.FromMinutes(alertMinutes);
+            var now = DateTime.UtcNow;
+
+            foreach (var (analysis, economics) in analyses)
+            {
+                active += analysis.ActiveExtractorCount;
+                idle += analysis.TotalExtractorCount - analysis.ActiveExtractorCount;
+                total += analysis.TotalExtractorCount;
+                factories += analysis.FactoryCount;
+
+                if (analysis.HasYieldData)
+                {
+                    grossIsk += economics.GrossIskPerDay;
+                    taxIsk += economics.TaxCostPerDay;
+                    hasYield = true;
+                }
+
+                // Count extractors expiring within lead time
+                foreach (var ext in analysis.Extractors)
+                {
+                    if (ext.Pin.ExpiryTime > now && (ext.Pin.ExpiryTime - now) <= leadTime)
+                        expiring++;
+                }
+
+                if (analysis.TimeUntilFirstIdle > TimeSpan.Zero && analysis.TimeUntilFirstIdle < earliestIdle)
+                    earliestIdle = analysis.TimeUntilFirstIdle;
+
+                if (GetHealthSeverity(analysis.Health) > GetHealthSeverity(worstHealth))
+                    worstHealth = analysis.Health;
+            }
+
+            ActiveExtractorCount = active;
+            IdleExtractorCount = idle;
+            ExpiringExtractorCount = expiring;
+            TotalExtractorCount = total;
+            FactoryCount = factories;
+            GrossIskPerDay = grossIsk;
+            TaxCostPerDay = taxIsk;
+            NetIskPerDay = grossIsk - taxIsk;
+            HasYieldData = hasYield;
+            TimeUntilFirstIdle = earliestIdle == TimeSpan.MaxValue ? TimeSpan.Zero : earliestIdle;
+            WorstHealth = worstHealth;
+            NeedsAttention = idle > 0 || worstHealth == ColonyHealthStatus.Idle || worstHealth == ColonyHealthStatus.Expiring;
+        }
+
+        private static int GetHealthSeverity(ColonyHealthStatus health) => health switch
+        {
+            ColonyHealthStatus.Optimal => 0,
+            ColonyHealthStatus.NoExtractors => 1,
+            ColonyHealthStatus.Expiring => 2,
+            ColonyHealthStatus.Idle => 3,
+            _ => 0
+        };
+    }
+}

--- a/tests/EveLens.Tests/Services/Planetary/ExtractionCalculatorTests.cs
+++ b/tests/EveLens.Tests/Services/Planetary/ExtractionCalculatorTests.cs
@@ -1,0 +1,307 @@
+// EveLens — Character Intelligence for EVE Online
+// Copyright © 2006-2021 EVEMon Development Team, © 2025-2026 Alia Collins
+// Built with Claude Code (Anthropic)
+// Licensed under GPL v2 — see LICENSE for details
+
+using System;
+using System.Linq;
+using EveLens.Common.Services.Planetary;
+using FluentAssertions;
+using Xunit;
+
+namespace EveLens.Tests.Services.Planetary
+{
+    /// <summary>
+    /// Cross-validates the extraction formula against the official EVE developer documentation.
+    /// Reference: https://developers.eveonline.com/docs/guides/pi/
+    /// Uses the same test parameters as the C#/Kotlin/Python reference implementations.
+    /// </summary>
+    public class ExtractionCalculatorTests
+    {
+        // Reference parameters from official docs
+        private const int ReferenceQtyPerCycle = 6965;
+        private const int ReferenceCycleTime = 30 * 60; // 30 minutes = 1800 seconds
+        private const int ReferenceDuration = 171000;   // 1d 23h 30m in seconds
+
+        [Fact]
+        public void CalculateCycleYields_MatchesReferenceImplementation()
+        {
+            // The official C# reference uses these exact parameters
+            var yields = ExtractionCalculator.CalculateCycleYields(
+                ReferenceQtyPerCycle, ReferenceCycleTime, ReferenceDuration);
+
+            // 171000 / 1800 = 95 cycles
+            yields.Should().HaveCount(95);
+
+            // barWidth = 1800/900 = 2.0, so each cycle value ≈ 2 * decayValue * (1+noise)
+            // First cycle output is significantly larger than raw qty_per_cycle due to barWidth multiplier
+            yields[0].Should().BeGreaterThan(0);
+            // With barWidth=2 and noise up to 1.8x, max possible ≈ 2 * 6965 * 1.8 ≈ 25,074
+            yields[0].Should().BeLessThan(26000);
+        }
+
+        [Fact]
+        public void CalculateCycleYields_FirstCycleHigherThanLast()
+        {
+            var yields = ExtractionCalculator.CalculateCycleYields(
+                ReferenceQtyPerCycle, ReferenceCycleTime, ReferenceDuration);
+
+            // Decay means first cycle > last cycle (on average, noise can cause local spikes)
+            // Use average of first 5 vs last 5 to smooth noise
+            double firstAvg = yields.Take(5).Average();
+            double lastAvg = yields.Skip(90).Take(5).Average();
+
+            firstAvg.Should().BeGreaterThan(lastAvg,
+                "extraction decays over time so early cycles yield more than late ones");
+        }
+
+        [Fact]
+        public void CalculateCycleYields_DecaysOverTime()
+        {
+            var yields = ExtractionCalculator.CalculateCycleYields(
+                ReferenceQtyPerCycle, ReferenceCycleTime, ReferenceDuration);
+
+            long actualTotal = yields.Sum(y => (long)y);
+            // Naive = first cycle * numCycles (what you'd get without decay)
+            long naiveTotal = ExtractionCalculator.CalculateNaiveTotal(
+                ReferenceQtyPerCycle, ReferenceCycleTime, ReferenceDuration);
+
+            // Actual should be less than naive because decay reduces later cycles
+            actualTotal.Should().BeLessThan(naiveTotal,
+                "decay reduces total yield compared to maintaining peak rate");
+
+            // Over a long program (95 cycles), heavy decay brings this to ~30-50% of peak
+            double ratio = (double)actualTotal / naiveTotal;
+            ratio.Should().BeInRange(0.25, 0.95,
+                "long programs decay significantly but short ones less so");
+        }
+
+        [Fact]
+        public void CalculateTotalYield_EqualsSum()
+        {
+            long total = ExtractionCalculator.CalculateTotalYield(
+                ReferenceQtyPerCycle, ReferenceCycleTime, ReferenceDuration);
+
+            var yields = ExtractionCalculator.CalculateCycleYields(
+                ReferenceQtyPerCycle, ReferenceCycleTime, ReferenceDuration);
+            long expectedTotal = yields.Sum(y => (long)y);
+
+            total.Should().Be(expectedTotal);
+        }
+
+        [Fact]
+        public void CalculateNaiveTotal_HigherThanActual()
+        {
+            long naive = ExtractionCalculator.CalculateNaiveTotal(
+                ReferenceQtyPerCycle, ReferenceCycleTime, ReferenceDuration);
+            long actual = ExtractionCalculator.CalculateTotalYield(
+                ReferenceQtyPerCycle, ReferenceCycleTime, ReferenceDuration);
+
+            naive.Should().BeGreaterThan(actual,
+                "naive estimate always overestimates because it ignores decay");
+        }
+
+        [Fact]
+        public void CalculateRemainingYield_AtStart_EqualsTotalYield()
+        {
+            long total = ExtractionCalculator.CalculateTotalYield(
+                ReferenceQtyPerCycle, ReferenceCycleTime, ReferenceDuration);
+            long remaining = ExtractionCalculator.CalculateRemainingYield(
+                ReferenceQtyPerCycle, ReferenceCycleTime, ReferenceDuration, 0);
+
+            remaining.Should().Be(total);
+        }
+
+        [Fact]
+        public void CalculateRemainingYield_AtEnd_ReturnsZero()
+        {
+            long remaining = ExtractionCalculator.CalculateRemainingYield(
+                ReferenceQtyPerCycle, ReferenceCycleTime, ReferenceDuration, ReferenceDuration);
+
+            remaining.Should().Be(0);
+        }
+
+        [Fact]
+        public void CalculateRemainingYield_AtHalfway_LessThanHalfTotal()
+        {
+            long total = ExtractionCalculator.CalculateTotalYield(
+                ReferenceQtyPerCycle, ReferenceCycleTime, ReferenceDuration);
+            long remaining = ExtractionCalculator.CalculateRemainingYield(
+                ReferenceQtyPerCycle, ReferenceCycleTime, ReferenceDuration, ReferenceDuration / 2);
+
+            // Due to decay, remaining at halfway should be less than half the total
+            remaining.Should().BeLessThan(total / 2,
+                "decay front-loads yield so the second half produces less");
+        }
+
+        [Fact]
+        public void CalculateYieldPerHourAtCycle_FirstCycle_PositiveRate()
+        {
+            double rate = ExtractionCalculator.CalculateYieldPerHourAtCycle(
+                ReferenceQtyPerCycle, ReferenceCycleTime, 0);
+
+            // 30-min cycles = 2 cycles/hr, so rate = 2 * first_cycle_yield
+            // first_cycle_yield ≈ 24000, so rate ≈ 48000/hr
+            rate.Should().BeGreaterThan(0);
+            rate.Should().BeLessThan(60000); // generous bound
+        }
+
+        [Fact]
+        public void CalculateYieldPerHourAtCycle_Decays()
+        {
+            double rateFirst = ExtractionCalculator.CalculateYieldPerHourAtCycle(
+                ReferenceQtyPerCycle, ReferenceCycleTime, 0);
+            double rateLast = ExtractionCalculator.CalculateYieldPerHourAtCycle(
+                ReferenceQtyPerCycle, ReferenceCycleTime, 94);
+
+            rateFirst.Should().BeGreaterThan(rateLast);
+        }
+
+        [Fact]
+        public void GenerateYieldCurve_ReturnsNormalizedValues()
+        {
+            var curve = ExtractionCalculator.GenerateYieldCurve(
+                ReferenceQtyPerCycle, ReferenceCycleTime, ReferenceDuration);
+
+            curve.Should().NotBeEmpty();
+            curve[0].Should().Be(1.0, "first point is normalized to 1.0");
+            curve.Should().OnlyContain(v => v >= 0 && v <= 1.0);
+        }
+
+        [Fact]
+        public void GenerateYieldCurve_RespectsMaxDataPoints()
+        {
+            var curve = ExtractionCalculator.GenerateYieldCurve(
+                ReferenceQtyPerCycle, ReferenceCycleTime, ReferenceDuration, 10);
+
+            // With ceiling division, may be maxDataPoints + 1 at most
+            curve.Length.Should().BeLessOrEqualTo(11);
+            curve.Length.Should().BeGreaterThan(5);
+        }
+
+        // ═══════════════════════════════════════════════════════════
+        // Cross-validation with known formula constants
+        // ═══════════════════════════════════════════════════════════
+
+        [Fact]
+        public void DecayFormula_WithZeroCycleIndex_MinimalDecay()
+        {
+            // At cycle 0: t = 0.5 * barWidth = 1.0 (barWidth = 1800/900 = 2)
+            // decayValue = 6965 / (1 + 1.0 * 0.012) = 6965 / 1.012 ≈ 6882
+            // Output = barWidth * barHeight = 2 * decayValue * (1 + 0.8*sinStuff)
+            // Range: 2 * 6882 * 1.0 = 13764 (sinStuff=0) to 2 * 6882 * 1.8 = 24775 (sinStuff=1)
+            var yields = ExtractionCalculator.CalculateCycleYields(6965, 1800, 3600);
+            yields.Should().HaveCount(2); // 3600 / 1800 = 2 cycles
+
+            yields[0].Should().BeInRange(13000, 25000);
+        }
+
+        [Fact]
+        public void ShortCycleTime_ProducesMoreCycles()
+        {
+            var yields15min = ExtractionCalculator.CalculateCycleYields(3000, 900, 86400);
+            var yields30min = ExtractionCalculator.CalculateCycleYields(3000, 1800, 86400);
+
+            yields15min.Length.Should().Be(96);   // 86400 / 900 = 96
+            yields30min.Length.Should().Be(48);   // 86400 / 1800 = 48
+        }
+
+        [Fact]
+        public void HighQtyPerCycle_ProducesHigherYields()
+        {
+            long totalLow = ExtractionCalculator.CalculateTotalYield(1000, 1800, 86400);
+            long totalHigh = ExtractionCalculator.CalculateTotalYield(10000, 1800, 86400);
+
+            totalHigh.Should().BeGreaterThan(totalLow);
+        }
+
+        // ═══════════════════════════════════════════════════════════
+        // Edge cases and invalid input
+        // ═══════════════════════════════════════════════════════════
+
+        [Theory]
+        [InlineData(0, 1800, 86400)]
+        [InlineData(6965, 0, 86400)]
+        [InlineData(6965, 1800, 0)]
+        [InlineData(-1, 1800, 86400)]
+        [InlineData(6965, -1, 86400)]
+        public void InvalidInputs_ReturnsEmpty(int qty, int cycle, int duration)
+        {
+            var yields = ExtractionCalculator.CalculateCycleYields(qty, cycle, duration);
+            yields.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void VeryShortDuration_LessThanOneCycle_ReturnsEmpty()
+        {
+            var yields = ExtractionCalculator.CalculateCycleYields(6965, 1800, 1799);
+            yields.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void AllYields_AreNonNegative()
+        {
+            // Test with various parameters to ensure we never get negative yields
+            var paramSets = new[]
+            {
+                (qty: 100, cycle: 900, dur: 86400),
+                (qty: 6965, cycle: 1800, dur: 171000),
+                (qty: 20000, cycle: 3600, dur: 345600),
+                (qty: 50, cycle: 600, dur: 14400),
+            };
+
+            foreach (var (qty, cycle, dur) in paramSets)
+            {
+                var yields = ExtractionCalculator.CalculateCycleYields(qty, cycle, dur);
+                yields.Should().OnlyContain(y => y >= 0,
+                    $"qty={qty}, cycle={cycle}, dur={dur} produced negative yields");
+            }
+        }
+
+        // ═══════════════════════════════════════════════════════════
+        // Formula verification against Python reference
+        // ═══════════════════════════════════════════════════════════
+
+        [Fact]
+        public void ManualFormulaCheck_FirstCycle_MatchesHandCalculation()
+        {
+            // Manually compute first cycle with reference values:
+            // qty_per_cycle = 6965, cycle_time = 1800s
+            // barWidth = 1800 / 900 = 2.0
+            // cycle 0: t = (0 + 0.5) * 2.0 = 1.0
+            // decayValue = 6965 / (1 + 1.0 * 0.012) = 6965 / 1.012 = 6882.41...
+            // phaseShift = 6965^0.7 = Math.Pow(6965, 0.7)
+            double phaseShift = Math.Pow(6965, 0.7);
+            double t = 1.0;
+            double decayValue = 6965.0 / (1.0 + t * 0.012);
+            double sinA = Math.Cos(phaseShift + t * (1.0 / 12.0));
+            double sinB = Math.Cos(phaseShift / 2.0 + t * 0.2);
+            double sinC = Math.Cos(t * 0.5);
+            double sinStuff = Math.Max((sinA + sinB + sinC) / 3.0, 0.0);
+            double barHeight = decayValue * (1.0 + 0.8 * sinStuff);
+            int expected = (int)(2.0 * barHeight);
+
+            var yields = ExtractionCalculator.CalculateCycleYields(6965, 1800, 3600);
+            yields[0].Should().Be(expected, "first cycle should exactly match hand calculation");
+        }
+
+        [Fact]
+        public void ManualFormulaCheck_TenthCycle()
+        {
+            // Cycle 9 (10th): t = (9 + 0.5) * 2.0 = 19.0
+            double barWidth = 2.0;
+            double t = 19.0;
+            double decayValue = 6965.0 / (1.0 + t * 0.012);
+            double phaseShift = Math.Pow(6965, 0.7);
+            double sinA = Math.Cos(phaseShift + t * (1.0 / 12.0));
+            double sinB = Math.Cos(phaseShift / 2.0 + t * 0.2);
+            double sinC = Math.Cos(t * 0.5);
+            double sinStuff = Math.Max((sinA + sinB + sinC) / 3.0, 0.0);
+            double barHeight = decayValue * (1.0 + 0.8 * sinStuff);
+            int expected = (int)(barWidth * barHeight);
+
+            var yields = ExtractionCalculator.CalculateCycleYields(6965, 1800, 86400);
+            yields[9].Should().Be(expected, "10th cycle should exactly match hand calculation");
+        }
+    }
+}

--- a/tests/EveLens.Tests/Services/Planetary/PlanetaryHealthAndNotificationTests.cs
+++ b/tests/EveLens.Tests/Services/Planetary/PlanetaryHealthAndNotificationTests.cs
@@ -1,0 +1,124 @@
+// EveLens — Character Intelligence for EVE Online
+// Copyright © 2006-2021 EVEMon Development Team, © 2025-2026 Alia Collins
+// Built with Claude Code (Anthropic)
+// Licensed under GPL v2 — see LICENSE for details
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using EveLens.Common.Enumerations;
+using EveLens.Common.Events;
+using EveLens.Common.Models;
+using EveLens.Common.Services;
+using EveLens.Common.Services.Planetary;
+using EveLens.Core.Interfaces;
+using EveLens.Tests.TestDoubles;
+using FluentAssertions;
+using Xunit;
+
+namespace EveLens.Tests.Services.Planetary
+{
+    public class PlanetaryHealthAndNotificationTests
+    {
+        [Fact]
+        public void ColonyHealthStatus_Enum_HasCorrectValues()
+        {
+            Enum.GetNames<ColonyHealthStatus>().Should().BeEquivalentTo(
+                new[] { "Optimal", "Expiring", "Idle", "NoExtractors" });
+        }
+
+        [Fact]
+        public void ColonyHealthStatus_Optimal_IsDefaultForRunningExtractors()
+        {
+            ColonyHealthStatus.Optimal.Should().Be(ColonyHealthStatus.Optimal);
+            ((int)ColonyHealthStatus.Optimal).Should().Be(0);
+        }
+
+        [Fact]
+        public void PinsExpiringEvent_AggregatesMultiplePins()
+        {
+            IEventAggregator aggregator = new EventAggregator();
+            var received = new List<CharacterPlanetaryPinsExpiringEvent>();
+            aggregator.Subscribe<CharacterPlanetaryPinsExpiringEvent>(e => received.Add(e));
+
+            var identity = new CharacterIdentity(1L, "Test Pilot");
+            var character = new CCPCharacter(identity, new NullCharacterServices());
+            var pins = new PlanetaryPin[] { };
+
+            aggregator.Publish(new CharacterPlanetaryPinsExpiringEvent(character, pins, TimeSpan.FromMinutes(120)));
+
+            received.Should().HaveCount(1);
+            received[0].Character.Should().BeSameAs(character);
+            received[0].LeadTime.Should().Be(TimeSpan.FromMinutes(120));
+        }
+
+        [Fact]
+        public void PinsCompletedEvent_AggregatesMultiplePins()
+        {
+            IEventAggregator aggregator = new EventAggregator();
+            var received = new List<CharacterPlanetaryPinsCompletedEvent>();
+            aggregator.Subscribe<CharacterPlanetaryPinsCompletedEvent>(e => received.Add(e));
+
+            var identity = new CharacterIdentity(1L, "Test Pilot");
+            var character = new CCPCharacter(identity, new NullCharacterServices());
+            var pins = new PlanetaryPin[] { };
+
+            aggregator.Publish(new CharacterPlanetaryPinsCompletedEvent(character, pins));
+
+            received.Should().HaveCount(1);
+            received[0].Character.Should().BeSameAs(character);
+            received[0].CompletedPins.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void MultipleCharacters_FireSeparateEvents()
+        {
+            IEventAggregator aggregator = new EventAggregator();
+            var received = new List<CharacterPlanetaryPinsCompletedEvent>();
+            aggregator.Subscribe<CharacterPlanetaryPinsCompletedEvent>(e => received.Add(e));
+
+            var char1 = new CCPCharacter(new CharacterIdentity(1L, "Alia"), new NullCharacterServices());
+            var char2 = new CCPCharacter(new CharacterIdentity(2L, "Saino"), new NullCharacterServices());
+            var char3 = new CCPCharacter(new CharacterIdentity(3L, "Tracy"), new NullCharacterServices());
+
+            aggregator.Publish(new CharacterPlanetaryPinsCompletedEvent(char1, Array.Empty<PlanetaryPin>()));
+            aggregator.Publish(new CharacterPlanetaryPinsCompletedEvent(char2, Array.Empty<PlanetaryPin>()));
+            aggregator.Publish(new CharacterPlanetaryPinsCompletedEvent(char3, Array.Empty<PlanetaryPin>()));
+
+            received.Should().HaveCount(3);
+            received.Select(e => e.Character.Name).Should().BeEquivalentTo(new[] { "Alia", "Saino", "Tracy" });
+        }
+
+        [Fact]
+        public void ExpiringEvent_CarriesLeadTime()
+        {
+            IEventAggregator aggregator = new EventAggregator();
+            CharacterPlanetaryPinsExpiringEvent? received = null;
+            aggregator.Subscribe<CharacterPlanetaryPinsExpiringEvent>(e => received = e);
+
+            var character = new CCPCharacter(new CharacterIdentity(1L, "Test"), new NullCharacterServices());
+            var leadTime = TimeSpan.FromMinutes(45);
+
+            aggregator.Publish(new CharacterPlanetaryPinsExpiringEvent(character, Array.Empty<PlanetaryPin>(), leadTime));
+
+            received.Should().NotBeNull();
+            received!.LeadTime.TotalMinutes.Should().Be(45);
+        }
+
+        [Fact]
+        public void ColonyAnalysis_HasYieldData_FalseWhenNoExtractorsHaveYield()
+        {
+            var analysis = ColonyAnalysis.Empty;
+            analysis.HasYieldData.Should().BeFalse();
+        }
+
+        [Fact]
+        public void ColonyAnalysis_Empty_HasNoExtractorsHealth()
+        {
+            ColonyAnalysis.Empty.Health.Should().Be(ColonyHealthStatus.NoExtractors);
+        }
+    }
+}

--- a/tests/EveLens.Tests/Services/Planetary/PlanetarySchematicsProviderTests.cs
+++ b/tests/EveLens.Tests/Services/Planetary/PlanetarySchematicsProviderTests.cs
@@ -1,0 +1,248 @@
+// EveLens — Character Intelligence for EVE Online
+// Copyright © 2006-2021 EVEMon Development Team, © 2025-2026 Alia Collins
+// Built with Claude Code (Anthropic)
+// Licensed under GPL v2 — see LICENSE for details
+
+using System.Linq;
+using EveLens.Common.Services.Planetary;
+using FluentAssertions;
+using Xunit;
+
+namespace EveLens.Tests.Services.Planetary
+{
+    public class PlanetarySchematicsProviderTests
+    {
+        // ═══════════════════════════════════════════════════════════
+        // Data Integrity (all 68 schematics loaded correctly)
+        // ═══════════════════════════════════════════════════════════
+
+        [Fact]
+        public void All_Contains68Schematics()
+        {
+            PlanetarySchematicsProvider.All.Should().HaveCount(68);
+        }
+
+        [Fact]
+        public void BasicTier_Has15Schematics()
+        {
+            PlanetarySchematicsProvider.GetSchematicsByTier(ProductionTier.Basic)
+                .Should().HaveCount(15, "there are 15 P0→P1 schematics in EVE");
+        }
+
+        [Fact]
+        public void AdvancedTier_Has24Schematics()
+        {
+            PlanetarySchematicsProvider.GetSchematicsByTier(ProductionTier.Advanced)
+                .Should().HaveCount(24, "there are 24 P1→P2 schematics in EVE");
+        }
+
+        [Fact]
+        public void AdvancedP3Tier_Has21Schematics()
+        {
+            PlanetarySchematicsProvider.GetSchematicsByTier(ProductionTier.AdvancedP3)
+                .Should().HaveCount(21, "there are 21 P2→P3 schematics in EVE");
+        }
+
+        [Fact]
+        public void HighTechTier_Has8Schematics()
+        {
+            PlanetarySchematicsProvider.GetSchematicsByTier(ProductionTier.HighTech)
+                .Should().HaveCount(8, "there are 8 P3→P4 schematics in EVE");
+        }
+
+        // ═══════════════════════════════════════════════════════════
+        // Specific schematic validation (cross-reference with SDE)
+        // ═══════════════════════════════════════════════════════════
+
+        [Fact]
+        public void Schematic121_Water_CorrectData()
+        {
+            var s = PlanetarySchematicsProvider.GetSchematic(121);
+            s.Should().NotBeNull();
+            s.Name.Should().Be("Water");
+            s.CycleTimeSeconds.Should().Be(1800);
+            s.Tier.Should().Be(ProductionTier.Basic);
+            s.Inputs.Should().HaveCount(1);
+            s.Inputs[0].TypeID.Should().Be(2268);  // Aqueous Liquids
+            s.Inputs[0].Quantity.Should().Be(3000);
+            s.Output.TypeID.Should().Be(3645);     // Water
+            s.Output.Quantity.Should().Be(20);
+        }
+
+        [Fact]
+        public void Schematic65_Superconductors_CorrectData()
+        {
+            var s = PlanetarySchematicsProvider.GetSchematic(65);
+            s.Should().NotBeNull();
+            s.Name.Should().Be("Superconductors");
+            s.CycleTimeSeconds.Should().Be(3600);
+            s.Tier.Should().Be(ProductionTier.Advanced);
+            s.Inputs.Should().HaveCount(2);
+            s.Inputs.Should().Contain(m => m.TypeID == 2389 && m.Quantity == 40); // Plasmoids
+            s.Inputs.Should().Contain(m => m.TypeID == 3645 && m.Quantity == 40); // Water
+            s.Output.TypeID.Should().Be(9838);    // Superconductors
+            s.Output.Quantity.Should().Be(5);
+        }
+
+        [Fact]
+        public void Schematic89_UkomiSuperconductor_P3Tier()
+        {
+            var s = PlanetarySchematicsProvider.GetSchematic(89);
+            s.Should().NotBeNull();
+            s.Name.Should().Be("Ukomi Superconductor");
+            s.Tier.Should().Be(ProductionTier.AdvancedP3);
+            s.Inputs.Should().HaveCount(2);
+            s.Inputs.Should().Contain(m => m.TypeID == 3691 && m.Quantity == 10); // Synthetic Oil
+            s.Inputs.Should().Contain(m => m.TypeID == 9838 && m.Quantity == 10); // Superconductors
+            s.Output.TypeID.Should().Be(17136);  // Ukomi Superconductor
+            s.Output.Quantity.Should().Be(3);
+        }
+
+        [Fact]
+        public void Schematic119_WetwareMainframe_P4Tier()
+        {
+            var s = PlanetarySchematicsProvider.GetSchematic(119);
+            s.Should().NotBeNull();
+            s.Name.Should().Be("Wetware Mainframe");
+            s.Tier.Should().Be(ProductionTier.HighTech);
+            s.Inputs.Should().HaveCount(3);
+            s.Output.TypeID.Should().Be(2876);  // Wetware Mainframe
+            s.Output.Quantity.Should().Be(1);
+        }
+
+        // ═══════════════════════════════════════════════════════════
+        // Lookup methods
+        // ═══════════════════════════════════════════════════════════
+
+        [Fact]
+        public void GetSchematicByOutputType_FindsCorrectSchematic()
+        {
+            // Water (3645) is produced by schematic 121
+            var s = PlanetarySchematicsProvider.GetSchematicByOutputType(3645);
+            s.Should().NotBeNull();
+            s.SchematicID.Should().Be(121);
+            s.Name.Should().Be("Water");
+        }
+
+        [Fact]
+        public void GetSchematicByOutputType_UnknownType_ReturnsNull()
+        {
+            PlanetarySchematicsProvider.GetSchematicByOutputType(99999)
+                .Should().BeNull();
+        }
+
+        [Fact]
+        public void GetSchematic_UnknownId_ReturnsNull()
+        {
+            PlanetarySchematicsProvider.GetSchematic(999).Should().BeNull();
+        }
+
+        // ═══════════════════════════════════════════════════════════
+        // Production rate calculations
+        // ═══════════════════════════════════════════════════════════
+
+        [Fact]
+        public void BasicFactory_OutputPerHour_Is40()
+        {
+            // P0→P1: 1800s cycle, 20 per cycle = 2 cycles/hr * 20 = 40/hr
+            var s = PlanetarySchematicsProvider.GetSchematic(121); // Water
+            s.GetOutputPerHour().Should().Be(40);
+        }
+
+        [Fact]
+        public void BasicFactory_InputDemandPerHour_Is6000()
+        {
+            // P0→P1: 1800s cycle, 3000 per cycle = 2 cycles/hr * 3000 = 6000/hr
+            var s = PlanetarySchematicsProvider.GetSchematic(121); // Water
+            s.GetInputDemandPerHour(2268).Should().Be(6000); // Aqueous Liquids
+        }
+
+        [Fact]
+        public void AdvancedFactory_OutputPerHour_Is5()
+        {
+            // P1→P2: 3600s cycle, 5 per cycle = 1 cycle/hr * 5 = 5/hr
+            var s = PlanetarySchematicsProvider.GetSchematic(65); // Superconductors
+            s.GetOutputPerHour().Should().Be(5);
+        }
+
+        [Fact]
+        public void AdvancedFactory_InputDemandPerHour_Is40()
+        {
+            // P1→P2: 3600s cycle, 40 per cycle = 1 cycle/hr * 40 = 40/hr
+            var s = PlanetarySchematicsProvider.GetSchematic(65); // Superconductors
+            s.GetInputDemandPerHour(2389).Should().Be(40); // Plasmoids
+            s.GetInputDemandPerHour(3645).Should().Be(40); // Water
+        }
+
+        [Fact]
+        public void P3Factory_OutputPerHour_Is3()
+        {
+            var s = PlanetarySchematicsProvider.GetSchematic(89); // Ukomi Superconductor
+            s.GetOutputPerHour().Should().Be(3);
+        }
+
+        [Fact]
+        public void P4Factory_OutputPerHour_Is1()
+        {
+            var s = PlanetarySchematicsProvider.GetSchematic(119); // Wetware Mainframe
+            s.GetOutputPerHour().Should().Be(1);
+        }
+
+        [Fact]
+        public void GetInputDemandPerHour_UnknownTypeId_ReturnsZero()
+        {
+            var s = PlanetarySchematicsProvider.GetSchematic(121);
+            s.GetInputDemandPerHour(99999).Should().Be(0);
+        }
+
+        // ═══════════════════════════════════════════════════════════
+        // Production chain consistency
+        // ═══════════════════════════════════════════════════════════
+
+        [Fact]
+        public void AllBasicSchematics_Have1800CycleTime()
+        {
+            foreach (var s in PlanetarySchematicsProvider.GetSchematicsByTier(ProductionTier.Basic))
+            {
+                s.CycleTimeSeconds.Should().Be(1800, $"Basic schematic {s.Name} should have 30min cycle");
+            }
+        }
+
+        [Fact]
+        public void AllAdvancedAndAbove_Have3600CycleTime()
+        {
+            foreach (var s in PlanetarySchematicsProvider.All.Values.Where(x => x.Tier != ProductionTier.Basic))
+            {
+                s.CycleTimeSeconds.Should().Be(3600, $"Schematic {s.Name} ({s.Tier}) should have 1hr cycle");
+            }
+        }
+
+        [Fact]
+        public void AllSchematics_HaveAtLeastOneInput()
+        {
+            foreach (var s in PlanetarySchematicsProvider.All.Values)
+            {
+                s.Inputs.Should().NotBeEmpty($"Schematic {s.Name} must have inputs");
+            }
+        }
+
+        [Fact]
+        public void AllSchematics_HavePositiveOutputQuantity()
+        {
+            foreach (var s in PlanetarySchematicsProvider.All.Values)
+            {
+                s.Output.Quantity.Should().BeGreaterThan(0, $"Schematic {s.Name} must produce something");
+            }
+        }
+
+        [Fact]
+        public void EachOutputType_IsUnique()
+        {
+            var outputTypes = PlanetarySchematicsProvider.All.Values
+                .Select(s => s.Output.TypeID)
+                .ToList();
+
+            outputTypes.Should().OnlyHaveUniqueItems("each item is produced by exactly one schematic");
+        }
+    }
+}

--- a/tests/EveLens.Tests/Services/Planetary/PlanetaryTaxCalculatorTests.cs
+++ b/tests/EveLens.Tests/Services/Planetary/PlanetaryTaxCalculatorTests.cs
@@ -1,0 +1,213 @@
+// EveLens — Character Intelligence for EVE Online
+// Copyright © 2006-2021 EVEMon Development Team, © 2025-2026 Alia Collins
+// Built with Claude Code (Anthropic)
+// Licensed under GPL v2 — see LICENSE for details
+
+using EveLens.Common.Services.Planetary;
+using FluentAssertions;
+using Xunit;
+
+namespace EveLens.Tests.Services.Planetary
+{
+    public class PlanetaryTaxCalculatorTests
+    {
+        // ═══════════════════════════════════════════════════════════
+        // Security Classification (uses raw value, not rounded)
+        // ═══════════════════════════════════════════════════════════
+
+        [Theory]
+        [InlineData(1.0f, PlanetaryTaxCalculator.SecurityClass.HighSec)]
+        [InlineData(0.9f, PlanetaryTaxCalculator.SecurityClass.HighSec)]
+        [InlineData(0.5f, PlanetaryTaxCalculator.SecurityClass.HighSec)]
+        [InlineData(0.45f, PlanetaryTaxCalculator.SecurityClass.HighSec)]     // boundary: >= 0.45
+        [InlineData(0.449f, PlanetaryTaxCalculator.SecurityClass.LowSec)]    // just below threshold
+        [InlineData(0.4f, PlanetaryTaxCalculator.SecurityClass.LowSec)]
+        [InlineData(0.1f, PlanetaryTaxCalculator.SecurityClass.LowSec)]
+        [InlineData(0.001f, PlanetaryTaxCalculator.SecurityClass.LowSec)]    // positive = lowsec
+        [InlineData(0.0f, PlanetaryTaxCalculator.SecurityClass.NullSec)]     // zero = null
+        [InlineData(-0.1f, PlanetaryTaxCalculator.SecurityClass.NullSec)]
+        [InlineData(-1.0f, PlanetaryTaxCalculator.SecurityClass.NullSec)]
+        public void GetSecurityClass_CorrectClassification(float secStatus, PlanetaryTaxCalculator.SecurityClass expected)
+        {
+            PlanetaryTaxCalculator.GetSecurityClass(secStatus).Should().Be(expected);
+        }
+
+        // ═══════════════════════════════════════════════════════════
+        // NPC Base Tax Rates
+        // ═══════════════════════════════════════════════════════════
+
+        [Fact]
+        public void NpcTaxRate_HighSec_Is10Percent()
+        {
+            PlanetaryTaxCalculator.GetNpcBaseTaxRate(PlanetaryTaxCalculator.SecurityClass.HighSec)
+                .Should().Be(0.10);
+        }
+
+        [Fact]
+        public void NpcTaxRate_LowSec_Is5Percent()
+        {
+            PlanetaryTaxCalculator.GetNpcBaseTaxRate(PlanetaryTaxCalculator.SecurityClass.LowSec)
+                .Should().Be(0.05);
+        }
+
+        [Fact]
+        public void NpcTaxRate_NullSec_IsZero()
+        {
+            PlanetaryTaxCalculator.GetNpcBaseTaxRate(PlanetaryTaxCalculator.SecurityClass.NullSec)
+                .Should().Be(0.0);
+        }
+
+        // ═══════════════════════════════════════════════════════════
+        // Customs Code Expertise Skill Reduction
+        // ═══════════════════════════════════════════════════════════
+
+        [Theory]
+        [InlineData(0.5f, 0, 0.10)]    // HighSec, no skill = full 10%
+        [InlineData(0.5f, 1, 0.09)]    // HighSec, L1 = 10% * (1 - 0.1) = 9%
+        [InlineData(0.5f, 2, 0.08)]    // HighSec, L2 = 10% * (1 - 0.2) = 8%
+        [InlineData(0.5f, 3, 0.07)]    // HighSec, L3 = 10% * (1 - 0.3) = 7%
+        [InlineData(0.5f, 4, 0.06)]    // HighSec, L4 = 10% * (1 - 0.4) = 6%
+        [InlineData(0.5f, 5, 0.05)]    // HighSec, L5 = 10% * (1 - 0.5) = 5%
+        public void EffectiveNpcTaxRate_HighSec_ReducedBySkill(float sec, int skillLevel, double expectedRate)
+        {
+            PlanetaryTaxCalculator.GetEffectiveNpcTaxRate(sec, skillLevel)
+                .Should().BeApproximately(expectedRate, 0.0001);
+        }
+
+        [Theory]
+        [InlineData(0.3f, 0, 0.05)]    // LowSec, no skill = 5%
+        [InlineData(0.3f, 5, 0.025)]   // LowSec, L5 = 5% * 0.5 = 2.5%
+        public void EffectiveNpcTaxRate_LowSec_ReducedBySkill(float sec, int skillLevel, double expectedRate)
+        {
+            PlanetaryTaxCalculator.GetEffectiveNpcTaxRate(sec, skillLevel)
+                .Should().BeApproximately(expectedRate, 0.0001);
+        }
+
+        [Theory]
+        [InlineData(-0.5f, 0, 0.0)]    // NullSec — always 0 regardless of skill
+        [InlineData(-0.5f, 5, 0.0)]
+        public void EffectiveNpcTaxRate_NullSec_AlwaysZero(float sec, int skillLevel, double expectedRate)
+        {
+            PlanetaryTaxCalculator.GetEffectiveNpcTaxRate(sec, skillLevel)
+                .Should().Be(expectedRate);
+        }
+
+        [Theory]
+        [InlineData(-1)]   // below valid
+        [InlineData(6)]    // above valid
+        [InlineData(99)]   // way above
+        public void EffectiveNpcTaxRate_ClampedSkillLevel(int invalidLevel)
+        {
+            // Should not throw, should clamp to valid range
+            var rate = PlanetaryTaxCalculator.GetEffectiveNpcTaxRate(0.5f, invalidLevel);
+            rate.Should().BeInRange(0.0, 0.10);
+        }
+
+        // ═══════════════════════════════════════════════════════════
+        // Total Export Tax Rate (NPC + POCO)
+        // ═══════════════════════════════════════════════════════════
+
+        [Fact]
+        public void TotalExportTax_NpcOnly_EqualsNpcRate()
+        {
+            double total = PlanetaryTaxCalculator.GetTotalExportTaxRate(0.5f, 0, null);
+            total.Should().Be(0.10); // NPC only, no POCO
+        }
+
+        [Fact]
+        public void TotalExportTax_WithPoco_AddsRates()
+        {
+            // HighSec, CCE L3 (7% NPC) + 10% POCO = 17%
+            double total = PlanetaryTaxCalculator.GetTotalExportTaxRate(0.5f, 3, 0.10);
+            total.Should().BeApproximately(0.17, 0.0001);
+        }
+
+        [Fact]
+        public void TotalExportTax_NullSecWithPoco_OnlyPoco()
+        {
+            // NullSec (0% NPC) + 15% POCO = 15%
+            double total = PlanetaryTaxCalculator.GetTotalExportTaxRate(-0.5f, 5, 0.15);
+            total.Should().BeApproximately(0.15, 0.0001);
+        }
+
+        // ═══════════════════════════════════════════════════════════
+        // Tax ISK Calculations
+        // ═══════════════════════════════════════════════════════════
+
+        [Fact]
+        public void CalculateExportTax_BasicMath()
+        {
+            // 1000 ISK base value, 100 units, 10% tax = 10,000 ISK
+            double tax = PlanetaryTaxCalculator.CalculateExportTax(1000, 100, 0.10);
+            tax.Should().Be(10000);
+        }
+
+        [Fact]
+        public void CalculateImportTax_HalfOfExportRate()
+        {
+            // Import is half the export rate
+            double exportTax = PlanetaryTaxCalculator.CalculateExportTax(1000, 100, 0.10);
+            double importTax = PlanetaryTaxCalculator.CalculateImportTax(1000, 100, 0.10);
+            importTax.Should().Be(exportTax / 2.0);
+        }
+
+        [Theory]
+        [InlineData(0, 100, 0.10)]
+        [InlineData(1000, 0, 0.10)]
+        [InlineData(1000, 100, 0)]
+        [InlineData(-1, 100, 0.10)]
+        public void CalculateExportTax_InvalidInputs_ReturnsZero(double baseValue, int qty, double rate)
+        {
+            PlanetaryTaxCalculator.CalculateExportTax(baseValue, qty, rate).Should().Be(0);
+        }
+
+        // ═══════════════════════════════════════════════════════════
+        // Security Status Rounding (EVE special rule)
+        // ═══════════════════════════════════════════════════════════
+
+        [Theory]
+        [InlineData(0.0, 0.0)]         // Zero stays zero
+        [InlineData(1.0, 1.0)]         // Max stays max
+        [InlineData(0.94, 0.9)]        // Normal rounding
+        [InlineData(0.95, 1.0)]        // Normal rounding up
+        [InlineData(0.45, 0.5)]        // Rounds to 0.5
+        [InlineData(0.44, 0.4)]        // Rounds to 0.4
+        [InlineData(-0.45, -0.5)]      // Negative: rounds away from zero
+        [InlineData(-0.55, -0.6)]      // Negative: rounds away from zero
+        public void RoundSecurityForDisplay_NormalRounding(double input, double expected)
+        {
+            PlanetaryTaxCalculator.RoundSecurityForDisplay(input)
+                .Should().BeApproximately(expected, 0.001);
+        }
+
+        [Theory]
+        [InlineData(0.01, 0.1)]        // Positive tiny → 0.1 (special rule)
+        [InlineData(0.001, 0.1)]       // Very tiny positive → 0.1
+        [InlineData(0.04, 0.1)]        // Below 0.05 → 0.1
+        [InlineData(0.05, 0.1)]        // Exactly 0.05 → 0.1 (boundary of special rule)
+        public void RoundSecurityForDisplay_SpecialPositiveRule(double input, double expected)
+        {
+            PlanetaryTaxCalculator.RoundSecurityForDisplay(input)
+                .Should().BeApproximately(expected, 0.001,
+                "positive values in (0, 0.05] must round to 0.1, never 0.0");
+        }
+
+        // ═══════════════════════════════════════════════════════════
+        // Security Color Codes
+        // ═══════════════════════════════════════════════════════════
+
+        [Theory]
+        [InlineData(1.0, "#2C75E1")]
+        [InlineData(0.9, "#399AEB")]
+        [InlineData(0.5, "#F5FF83")]
+        [InlineData(0.4, "#DC6C06")]
+        [InlineData(0.1, "#731F1F")]
+        [InlineData(0.01, "#731F1F")]   // rounds to 0.1 via special rule
+        [InlineData(-0.1, "#8D3163")]
+        [InlineData(-1.0, "#8D3163")]
+        public void GetSecurityColor_MatchesEveStandard(double sec, string expectedHex)
+        {
+            PlanetaryTaxCalculator.GetSecurityColor(sec).Should().Be(expectedHex);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- **Planetary Interaction overhaul (Beta)** — timer-based health, conditional economics, alert timeline, in-app toast notifications, bell badge alerts (#66)
- **Plan Editor attribute ordering fixed** — now matches in-game: PER, MEM, WIL, INT, CHA (#74)
- **Activity log flyout fixed** — replaced Flyout with Popup to prevent right-edge clipping, shortened SSO error message (#68)
- **Overview cards: location + ship** — shows solar system and active ship type on character cards
- **Overview cards: Omega/Alpha badge below portrait** — frees horizontal space
- **Character drag-reorder** — "Reorder" mode on overview, drag cards within groups, persists order, upper portrait strip syncs
- **Manage Groups button** — accessible directly from overview toolbar
- **Branch protection** — main/alpha/beta require PRs, promote.ps1 updated to use PR flow
- **In-app toast notifications** — PI alerts show bottom-right corner toasts
- **OS toast notifications** — single debounced "PI needs attention" toast (5min cooldown)

## Test plan

- [ ] Open Plan Editor → verify attribute order is PER, MEM, WIL, INT, CHA
- [ ] Click bell icon → activity log popup fully visible with Mark Read + Clear buttons
- [ ] Overview cards show system name + ship type after ESI fetch
- [ ] Click "Reorder" → drag cards → verify order persists after restart
- [ ] Upper portrait strip reflects new order after drag
- [ ] PI tab shows beta banner, timer-focused cards
- [ ] Debug menu → Fire PI events → in-app toast appears
- [ ] All 1969 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)