### PR TITLE
Dedupe CHANGELOG Unreleased lines (beta.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 - Beta feedback fixes: plan delete (#80), PI idle/product/layout (#66), hide-maxed filter (#71)
-- Beta feedback fixes: plan delete (#80), PI idle/product/layout (#66), hide-maxed filter (#71)
-- Beta feedback fixes: plan delete (#80), PI idle/product/layout (#66), hide-maxed filter (#71)
-- Beta feedback fixes: plan delete (#80), PI idle/product/layout (#66), hide-maxed filter (#71)
 - Skill Farm configurable base SP, What's New dialog, Code Graph system
 
 ### Added


### PR DESCRIPTION
Collapses 4 duplicate promote-summary one-liners (artifact of re-running promote.ps1 during the beta.1->beta.2 version correction) into one. Categorized release-note sections were unaffected.