### PR TITLE
release.ps1: serial Windows signing for cloud SimplySign token

### DIFF
--- a/scripts/release.ps1
+++ b/scripts/release.ps1
@@ -34,6 +34,17 @@ Push-Location $ProjectRoot
 # ── Configuration ──
 $CertThumbprint = "790D3430F3154FC6ACE68E0F5701D165BFFD3BC9"
 $TimestampUrl = "http://time.certum.pl"
+
+# Locate signtool.exe (latest Windows SDK). Used by the serial signing template below.
+# Resolve to its 8.3 short path: the full path contains spaces ("Program Files (x86)"),
+# and vpk's --signTemplate splits the command on whitespace, so a quoted long path is
+# mis-parsed ("Unrecognized command or argument 'Files'"). The short path has no spaces.
+$SignTool = Get-ChildItem "${env:ProgramFiles(x86)}\Windows Kits\10\bin\*\x64\signtool.exe" -ErrorAction SilentlyContinue |
+    Sort-Object FullName -Descending | Select-Object -First 1 -ExpandProperty FullName
+if ($SignTool) {
+    $fso = New-Object -ComObject Scripting.FileSystemObject
+    $SignTool = $fso.GetFile($SignTool).ShortPath
+}
 $MainProject = "src/EveLens.Avalonia/EveLens.Avalonia.csproj"
 $AppName = "EveLens"
 $Repo = "aliacollins/EveLens"
@@ -150,11 +161,16 @@ try {
     if (Test-Path $WinPlatform.Out) { Remove-Item $WinPlatform.Out -Recurse -Force }
 
     $ErrorActionPreference = 'Continue'
+    # Use --signTemplate (one signtool invocation per file) instead of --signParams.
+    # --signParams signs with parallelism 10, which exhausts the cloud-based SimplySign
+    # virtual token and fails partway ("No certificates were found that met all the given
+    # criteria"). Serial signing via the template is reliable against the cloud token.
+    $signCmd = "$SignTool sign /sha1 $CertThumbprint /fd SHA256 /tr $TimestampUrl /td SHA256 {{file}}"
     & $vpkPath pack `
         -u $AppName -v $Version `
         -p $WinPlatform.Dir -e $WinPlatform.Exe `
         --channel $Channel `
-        --signParams "/sha1 $CertThumbprint /fd SHA256 /tr $TimestampUrl /td SHA256" `
+        --signTemplate $signCmd `
         -o $WinPlatform.Out 2>&1 | ForEach-Object { $_ }
     $ErrorActionPreference = 'Stop'
     if ($LASTEXITCODE -ne 0) { throw "Pack failed for win-x64." }


### PR DESCRIPTION
Fixes the beta.2 release-signing failure. Velopack --signParams (parallelism 10) exhausts the cloud SimplySign token; switched to --signTemplate (serial, one file per signtool call). Verified locally: signs steadily 1-by-1 with no token errors. Uses signtool 8.3 short path to avoid vpk template whitespace-split parsing.