### PR TITLE
Correct alpha version to 1.4.0-alpha.4

### DIFF
--- a/SharedAssemblyInfo.cs
+++ b/SharedAssemblyInfo.cs
@@ -30,9 +30,9 @@ using System.Runtime.InteropServices;
 //      Build Number
 //      Revision (0 for stable, 1+ for beta)
 //
-[assembly: AssemblyVersion("1.4.0.1")]
-[assembly: AssemblyFileVersion("1.4.0.1")]
-[assembly: AssemblyInformationalVersion("1.4.0-alpha.1")]
+[assembly: AssemblyVersion("1.4.0.4")]
+[assembly: AssemblyFileVersion("1.4.0.4")]
+[assembly: AssemblyInformationalVersion("1.4.0-alpha.4")]
 
 // Neutral Language
 [assembly: NeutralResourcesLanguage("en-US")]

--- a/updates/evelens-patch-alpha.xml
+++ b/updates/evelens-patch-alpha.xml
@@ -7,11 +7,11 @@
   <releases>
     <release>
       <date>2026-06-04</date>
-      <version>1.4.0.1</version>
+      <version>1.4.0.4</version>
       <url>https://github.com/aliacollins/evelens/releases/tag/alpha</url>
       <autopatchurl>https://github.com/aliacollins/evelens/releases/download/alpha/EveLens-install-1.4.0.exe</autopatchurl>
       <autopatchargs>/SILENT</autopatchargs>
-      <message><![CDATA[EveLens 1.4.0-alpha.1
+      <message><![CDATA[EveLens 1.4.0-alpha.4
 
 i18n architecture: data-file UI strings, LanguageRegistry, {loc:T} markup, .LocalizedName fixes, market-group SDE names]]></message>
     </release>


### PR DESCRIPTION
Promote miscomputed the version (feature branch based on beta.3 -> stamped alpha.1, regressing past alpha.3). Code is intact; this fixes only the version strings to 1.4.0-alpha.4.