### PR TITLE
docs: tidy CHANGELOG — archive beta.4 entries, reset [Unreleased] to beta.5 items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- i18n architecture: data-file UI strings, LanguageRegistry, {loc:T} markup, .LocalizedName fixes, market-group SDE names
-- Korean (ko) language support: 464 UI strings + 50K SDE names (Discussion #79)
-- Korean (ko) language support: 464 UI strings + 50K SDE names (Discussion #79)
-- Beta feedback fixes: plan delete (#80), PI idle/product/layout (#66), hide-maxed filter (#71)
-- Skill Farm configurable base SP, What's New dialog, Code Graph system
+
+### Security
+
+- **Updated MailKit to 4.16.0** -- Clears two moderate-severity advisories in the email/MimeKit stack (STARTTLS response injection CVE-2026-41319 and CRLF/SMTP injection CVE-2026-30227). Email skill-completion alerts are unaffected. Also removed an unused MailKit dependency from EveLens.Infrastructure.
+
+### Fixed
+
+- **Linux/macOS: hard crash opening Standings, Contacts, Employment History, and Loyalty tabs** -- Default/placeholder images were loaded through a Windows-only graphics library (System.Drawing/GDI+), which throws on Linux and macOS the instant it runs. Opening any of those tabs terminated the whole app with no error. Default images now use the same cross-platform image pipeline (SkiaSharp) as the rest of EveLens, so the tabs work on every platform.
+- **Crashes no longer kill the app silently** -- EveLens now installs a process-wide safety net (unhandled exception, unobserved background task, and UI-thread handlers). An unexpected error is logged and, where possible, the app keeps running instead of vanishing without a trace.
+- **"Error logging in to EVE SSO" now explains itself and stops spamming** -- This generic banner appeared for every kind of token failure, and an expired refresh token retried every few seconds forever -- so an idle character could flood you with a login error it could never clear. EveLens now reads CCP's actual reason and reacts accordingly: an expired session names the specific character to re-authenticate (and stops retrying a token that can't work), bad ESI app credentials point you to Settings, and brief network/server hiccups retry quietly without raising a scary alarm. The banner also clears itself automatically once a character re-authenticates. CCP's raw response is still written to the log and diagnostic stream for deeper diagnosis (Issue #94).
+
+## [1.4.0-beta.4] - 2026-06-04
 
 ### Added
 
@@ -35,15 +42,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Release asset naming** — macOS and Linux release assets now use channel-based names (e.g. `EveLens-stable-linux-x86_64.AppImage`) so download links never go stale between versions
 - **EveLens branded icons** — All platform icons (Windows, macOS, Linux) replaced with proper EveLens logo at all resolutions
 
-### Security
-
-- **Updated MailKit to 4.16.0** -- Clears two moderate-severity advisories in the email/MimeKit stack (STARTTLS response injection CVE-2026-41319 and CRLF/SMTP injection CVE-2026-30227). Email skill-completion alerts are unaffected. Also removed an unused MailKit dependency from EveLens.Infrastructure.
-
 ### Fixed
 
-- **Linux/macOS: hard crash opening Standings, Contacts, Employment History, and Loyalty tabs** -- Default/placeholder images were loaded through a Windows-only graphics library (System.Drawing/GDI+), which throws on Linux and macOS the instant it runs. Opening any of those tabs terminated the whole app with no error. Default images now use the same cross-platform image pipeline (SkiaSharp) as the rest of EveLens, so the tabs work on every platform.
-- **Crashes no longer kill the app silently** -- EveLens now installs a process-wide safety net (unhandled exception, unobserved background task, and UI-thread handlers). An unexpected error is logged and, where possible, the app keeps running instead of vanishing without a trace.
-- **"Error logging in to EVE SSO" now explains itself and stops spamming** -- This generic banner appeared for every kind of token failure, and an expired refresh token retried every few seconds forever -- so an idle character could flood you with a login error it could never clear. EveLens now reads CCP's actual reason and reacts accordingly: an expired session names the specific character to re-authenticate (and stops retrying a token that can't work), bad ESI app credentials point you to Settings, and brief network/server hiccups retry quietly without raising a scary alarm. The banner also clears itself automatically once a character re-authenticates. CCP's raw response is still written to the log and diagnostic stream for deeper diagnosis (Issue #94).
 - **Plan editor: Delete key removed the wrong skill** -- Pressing Delete deleted the top skill in the queue (and its dependents) instead of the skill you had selected. Delete now acts on your actual selection, and supports multi-select (#80)
 - **Planetary Interaction: idle colonies stopped showing red** -- Colony health was frozen at the moment data first loaded, so a colony that went idle while EveLens was open never turned red until restart. Extractor state is now computed live and the dashboard repaints when colony data refreshes or an extractor finishes (#66)
 - **Planetary Interaction: final product showed "Unknown"** -- Actively-extracting colonies route material onward immediately, leaving the extractor's contents empty, so EveLens couldn't name the product. It now reads the extractor's declared output type, resolving the correct product (#66)


### PR DESCRIPTION
## What

`CHANGELOG.md` `[Unreleased]` had accumulated every entry from 1.3.0 through beta.4 (plus duplicate lines), because past releases published straight from `[Unreleased]` without ever archiving into a versioned section.

This PR:
- Moves the already-shipped content into a dated `## [1.4.0-beta.4] - 2026-06-04` section (matches the published `v1.4.0-beta.4` release notes).
- Leaves `[Unreleased]` holding only the **new beta.5 work**:
  - **Security:** MailKit -> 4.16.0 (CVE-2026-41319, CVE-2026-30227)
  - **Fixed:** Linux/macOS GDI+ crash, process-wide crash backstop, SSO token error classification + retry spam (#94)

## Why

So the next `release.ps1` (which builds beta release notes from `[Unreleased]`) emits accurate notes for beta.5 instead of repeating three prior betas.

Docs-only; no code or test changes.