### PR TITLE
docs: tidy beta.5 release notes (drop summary line, README header to 1.4.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- Non-Windows stability: crash backstop, GDI+ default-image fix, SSO token error classification (#94), MailKit CVE
 
 ### Security
 

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ I'm not accepting donations -- I just want to know if EveLens makes your EVE lif
 
 ---
 
-## What's New in 1.3.0
+## What's New in 1.4.0
 
 - **Doctrine Designer** -- create shared skill templates, assign characters, compare training times, generate personal plans (Ctrl+G)
 - **Chinese language (简体中文)** -- full UI + 50K SDE translations with CCP official game terms


### PR DESCRIPTION
Two small docs tidy-ups ahead of the beta.5 release build:

- Remove the redundant one-line summary at the top of CHANGELOG `[Unreleased]` (promote.ps1 prepends it) so the public release notes are clean structured sections only.
- Bump README `## What's New` header from 1.3.0 to 1.4.0.

Docs-only; no code/test changes.