### PR TITLE
Alpha 1.4.0-alpha.6: promote.ps1: unambiguous refs/heads merges + post-merge content verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- promote.ps1: unambiguous refs/heads merges + post-merge content verification
 - beta.5 train: community fixes, SDE 3458726, Attribute Optimizer, EVE Accuracy Suite, auto-update opt-in
 
 ### Added

--- a/SharedAssemblyInfo.cs
+++ b/SharedAssemblyInfo.cs
@@ -30,9 +30,9 @@ using System.Runtime.InteropServices;
 //      Build Number
 //      Revision (0 for stable, 1+ for beta)
 //
-[assembly: AssemblyVersion("1.4.0.5")]
-[assembly: AssemblyFileVersion("1.4.0.5")]
-[assembly: AssemblyInformationalVersion("1.4.0-alpha.5")]
+[assembly: AssemblyVersion("1.4.0.6")]
+[assembly: AssemblyFileVersion("1.4.0.6")]
+[assembly: AssemblyInformationalVersion("1.4.0-alpha.6")]
 
 // Neutral Language
 [assembly: NeutralResourcesLanguage("en-US")]

--- a/scripts/promote.ps1
+++ b/scripts/promote.ps1
@@ -504,8 +504,16 @@ function Invoke-GitMerge {
         git checkout -B $TargetBranch "refs/heads/$TargetBranch"
         if ($LASTEXITCODE -ne 0) { throw "git checkout $TargetBranch failed (exit code $LASTEXITCODE)" }
 
+        # CRITICAL: merge by explicit refs/heads/ — a bare branch name is ambiguous when a
+        # tag with the same name exists, and git resolves the TAG. This exact failure shipped
+        # v1.4.0 built from the months-old 'beta' release TAG instead of the beta branch.
+        $sourceRef = "refs/heads/$SourceBranch"
+        git show-ref --verify --quiet $sourceRef
+        if ($LASTEXITCODE -ne 0) { throw "Source branch '$SourceBranch' does not exist as a local branch ($sourceRef)" }
+        $expectedTip = git rev-parse $sourceRef
+
         # First try a normal merge
-        git merge $SourceBranch --no-ff -m "Merge $SourceBranch into $TargetBranch"
+        git merge $sourceRef --no-ff -m "Merge $SourceBranch into $TargetBranch"
         if ($LASTEXITCODE -ne 0) {
             # Merge conflicted — abort and retry with -X theirs strategy.
             # Cross-branch promotes (alpha→beta, beta→stable) always conflict on
@@ -514,12 +522,21 @@ function Invoke-GitMerge {
             # branch content, then Phase 3 applies the correct target version on top.
             git merge --abort 2>$null
             Write-Warning "Normal merge conflicted. Retrying with source-wins strategy..."
-            git merge $SourceBranch --no-ff -X theirs -m "Merge $SourceBranch into $TargetBranch"
+            git merge $sourceRef --no-ff -X theirs -m "Merge $SourceBranch into $TargetBranch"
             if ($LASTEXITCODE -ne 0) {
                 git merge --abort 2>$null
                 throw "Merge conflict: $SourceBranch into $TargetBranch failed even with -X theirs. Manual resolution required."
             }
         }
+
+        # POST-MERGE CONTENT VERIFICATION: the source branch tip must now be an ancestor of
+        # the target. If it isn't, the merge brought in something other than the branch we
+        # asked for — hard stop before anything gets pushed or released.
+        git merge-base --is-ancestor $expectedTip HEAD
+        if ($LASTEXITCODE -ne 0) {
+            throw "CONTENT VERIFICATION FAILED: $SourceBranch tip ($expectedTip) is not contained in the merge result. The merge picked up the wrong ref. Aborting."
+        }
+        Write-Success "Content verified: $SourceBranch tip $($expectedTip.Substring(0,9)) is in the merge"
     }
     Write-Success "Merged $SourceBranch -> $TargetBranch"
 }
@@ -700,17 +717,31 @@ function Invoke-Promote {
                 git checkout -B $promoteBranch "origin/$targetBranch"
                 if ($LASTEXITCODE -ne 0) { throw "git checkout promote branch from $targetBranch failed" }
 
+                # CRITICAL: merge by explicit refs/heads/ — a bare name resolves to a TAG when
+                # one shares the name (this shipped v1.4.0 from the stale 'beta' release tag).
+                $sourceRef = "refs/heads/$currentBranch"
+                git show-ref --verify --quiet $sourceRef
+                if ($LASTEXITCODE -ne 0) { throw "Source branch '$currentBranch' does not exist as a local branch ($sourceRef)" }
+                $expectedTip = git rev-parse $sourceRef
+
                 # Merge source branch into promote branch
-                git merge $currentBranch --no-ff -m "Merge $currentBranch into $targetBranch"
+                git merge $sourceRef --no-ff -m "Merge $currentBranch into $targetBranch"
                 if ($LASTEXITCODE -ne 0) {
                     git merge --abort 2>$null
                     Write-Warning "Normal merge conflicted. Retrying with source-wins strategy..."
-                    git merge $currentBranch --no-ff -X theirs -m "Merge $currentBranch into $targetBranch"
+                    git merge $sourceRef --no-ff -X theirs -m "Merge $currentBranch into $targetBranch"
                     if ($LASTEXITCODE -ne 0) {
                         git merge --abort 2>$null
                         throw "Merge conflict: $currentBranch into promote branch failed even with -X theirs. Manual resolution required."
                     }
                 }
+
+                # POST-MERGE CONTENT VERIFICATION: source tip must be an ancestor of the result
+                git merge-base --is-ancestor $expectedTip HEAD
+                if ($LASTEXITCODE -ne 0) {
+                    throw "CONTENT VERIFICATION FAILED: $currentBranch tip ($expectedTip) is not in the merge result. Wrong ref was merged. Aborting."
+                }
+                Write-Success "Content verified: $currentBranch tip $($expectedTip.Substring(0,9)) is in the merge"
                 Write-Success "Merged $currentBranch into promote branch"
             }
         } catch {

--- a/updates/evelens-patch-alpha.xml
+++ b/updates/evelens-patch-alpha.xml
@@ -7,6 +7,16 @@
   <releases>
     <release>
       <date>2026-08-10</date>
+      <version>1.4.0.6</version>
+      <url>https://github.com/aliacollins/evelens/releases/tag/alpha</url>
+      <autopatchurl>https://github.com/aliacollins/evelens/releases/download/alpha/EveLens-install-1.4.0.exe</autopatchurl>
+      <autopatchargs>/SILENT</autopatchargs>
+      <message><![CDATA[EveLens 1.4.0-alpha.6
+
+promote.ps1: unambiguous refs/heads merges + post-merge content verification]]></message>
+    </release>
+    <release>
+      <date>2026-08-10</date>
       <version>1.4.0.5</version>
       <url>https://github.com/aliacollins/evelens/releases/tag/alpha</url>
       <autopatchurl>https://github.com/aliacollins/evelens/releases/download/alpha/EveLens-install-1.4.0.exe</autopatchurl>
@@ -94,16 +104,6 @@ Consistent skill counts: filter unpublished skills uniformly (#37, #33)]]></mess
       <message><![CDATA[EveLens 1.1.0-alpha.7
 
 Show full character names in Skill Comparison (#45)]]></message>
-    </release>
-    <release>
-      <date>2026-03-29</date>
-      <version>1.1.0.6</version>
-      <url>https://github.com/aliacollins/evelens/releases/tag/alpha</url>
-      <autopatchurl>https://github.com/aliacollins/evelens/releases/download/alpha/EveLens-install-1.1.0.exe</autopatchurl>
-      <autopatchargs>/SILENT</autopatchargs>
-      <message><![CDATA[EveLens 1.1.0-alpha.6
-
-Fix live font scaling in code-behind windows (#42 feedback)]]></message>
     </release>
   </releases>
   <datafiles>


### PR DESCRIPTION
Automated promotion: fix/promote-tag-ambiguity -> alpha (1.4.0-alpha.6)

promote.ps1: unambiguous refs/heads merges + post-merge content verification