### PR TITLE
Beta 1.5.0-beta.3: Beta 3: SKINR geometry converter ships inside Render Runtime 1.0.3; runtime updates in place

### DIFF
--- a/SharedAssemblyInfo.cs
+++ b/SharedAssemblyInfo.cs
@@ -30,9 +30,9 @@ using System.Runtime.InteropServices;
 //      Build Number
 //      Revision (0 for stable, 1+ for beta)
 //
-[assembly: AssemblyVersion("1.5.0.1")]
-[assembly: AssemblyFileVersion("1.5.0.1")]
-[assembly: AssemblyInformationalVersion("1.5.0-beta.1")]
+[assembly: AssemblyVersion("1.5.0.3")]
+[assembly: AssemblyFileVersion("1.5.0.3")]
+[assembly: AssemblyInformationalVersion("1.5.0-beta.3")]
 
 // Neutral Language
 [assembly: NeutralResourcesLanguage("en-US")]

--- a/scripts/promote.ps1
+++ b/scripts/promote.ps1
@@ -32,6 +32,13 @@ param(
     [Parameter(Mandatory=$false)]
     [string]$Message,
 
+    # Explicit version override. The computed next-version depends on reading the
+    # target branch's SharedAssemblyInfo, and a failed/stale read has twice stamped
+    # a colliding version (2026-06-03, 2026-08-26). When the right answer is known,
+    # say it outright: promote.ps1 beta -Version 1.5.0-beta.3
+    [Parameter(Mandatory=$false)]
+    [string]$Version,
+
     [switch]$SkipBuild,
     [switch]$DryRun
 )
@@ -615,7 +622,16 @@ function Test-GitHubRelease {
 function Invoke-Promote {
     $currentBranch = Get-CurrentBranch
     $currentVersion = Get-CurrentVersion
-    $nextVersion = Get-NextVersion $currentVersion $Channel
+    $nextVersion = if ($Version) {
+        # Sanity: the override must parse and belong to the target channel.
+        $pv = Parse-Version $Version
+        if ($pv.Channel -ne $Channel -and -not ($Channel -eq "stable" -and $pv.Channel -eq "stable")) {
+            throw "-Version '$Version' does not belong to channel '$Channel'."
+        }
+        $Version
+    } else {
+        Get-NextVersion $currentVersion $Channel
+    }
 
     Write-Host ""
     Write-Host "============================================" -ForegroundColor White

--- a/updates/evelens-patch-beta.xml
+++ b/updates/evelens-patch-beta.xml
@@ -7,6 +7,16 @@
   <releases>
     <release>
       <date>2026-08-26</date>
+      <version>1.5.0.3</version>
+      <url>https://github.com/aliacollins/evelens/releases/tag/beta</url>
+      <autopatchurl>https://github.com/aliacollins/evelens/releases/download/beta/EveLens-install-1.5.0.exe</autopatchurl>
+      <autopatchargs>/SILENT</autopatchargs>
+      <message><![CDATA[EveLens 1.5.0-beta.3
+
+Beta 3: SKINR geometry converter ships inside Render Runtime 1.0.3; runtime updates in place]]></message>
+    </release>
+    <release>
+      <date>2026-08-26</date>
       <version>1.5.0.1</version>
       <url>https://github.com/aliacollins/evelens/releases/tag/beta</url>
       <autopatchurl>https://github.com/aliacollins/evelens/releases/download/beta/EveLens-install-1.5.0.exe</autopatchurl>
@@ -92,16 +102,6 @@ Korean (ko) language support: 464 UI strings + 50K SDE names (Discussion #79)]]>
       <autopatchurl>https://github.com/aliacollins/evelens/releases/download/beta/EveLens-install-1.4.0.exe</autopatchurl>
       <autopatchargs>/SILENT</autopatchargs>
       <message><![CDATA[EveLens 1.4.0-beta.2
-
-Beta feedback fixes: plan delete (#80), PI idle/product/layout (#66), hide-maxed filter (#71)]]></message>
-    </release>
-    <release>
-      <date>2026-06-03</date>
-      <version>1.4.0.1</version>
-      <url>https://github.com/aliacollins/evelens/releases/tag/beta</url>
-      <autopatchurl>https://github.com/aliacollins/evelens/releases/download/beta/EveLens-install-1.4.0.exe</autopatchurl>
-      <autopatchargs>/SILENT</autopatchargs>
-      <message><![CDATA[EveLens 1.4.0-beta.1
 
 Beta feedback fixes: plan delete (#80), PI idle/product/layout (#66), hide-maxed filter (#71)]]></message>
     </release>


### PR DESCRIPTION
Automated promotion: experimental/skinr -> beta (1.5.0-beta.3)

Beta 3: SKINR geometry converter ships inside Render Runtime 1.0.3; runtime updates in place