### PR TITLE
Beta 1.5.0-beta.5: Beta 5: Mac SKINR usable without the renderer; macOS/Linux update checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.5.0-beta.4] - 2026-08-26
+
 ### Fixed
 
 - **Mac: SKINR no longer dangles an Install button that cannot work** -- On Apple Silicon, clicking a design could surface the runtime install offer, whose Install click then reported "service unreachable - try again" forever: the Metal runtime is not published yet, and one code path missed that check. The availability decision now lives in one place, so every path shows the honest "Metal renderer coming" message until the day the Mac runtime actually ships.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **macOS and Linux now get update checks** -- The auto-updater only worked on Windows (the mac .app and Linux archives are hand-packaged, so the update engine considered itself not installed and went silent). Both platforms now check GitHub Releases in the background on the same schedule as Windows and notify when a newer build for your channel exists; Help > Check for Updates opens the download page. Version comparison is numeric now too -- the old manual check ordered beta.10 before beta.4 and misread the channel, so it could claim you were current when you were not.
+
 ## [1.5.0-beta.4] - 2026-08-26
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Mac: the SKINR window is usable without the renderer** -- On Apple Silicon the marketplace's background thumbnail engine tried to render every design through a 3D engine that is not installed yet: hundreds of doomed attempts that kept the window busy and every card stuck on "preparing". Without a local engine it now fills cards only from opted-in community previews and parks the rest quietly -- and the moment the Metal runtime installs, those designs get their real renders.
 - **macOS and Linux now get update checks** -- The auto-updater only worked on Windows (the mac .app and Linux archives are hand-packaged, so the update engine considered itself not installed and went silent). Both platforms now check GitHub Releases in the background on the same schedule as Windows and notify when a newer build for your channel exists; Help > Check for Updates opens the download page. Version comparison is numeric now too -- the old manual check ordered beta.10 before beta.4 and misread the channel, so it could claim you were current when you were not.
 
 ## [1.5.0-beta.4] - 2026-08-26

--- a/SharedAssemblyInfo.cs
+++ b/SharedAssemblyInfo.cs
@@ -30,9 +30,9 @@ using System.Runtime.InteropServices;
 //      Build Number
 //      Revision (0 for stable, 1+ for beta)
 //
-[assembly: AssemblyVersion("1.5.0.4")]
-[assembly: AssemblyFileVersion("1.5.0.4")]
-[assembly: AssemblyInformationalVersion("1.5.0-beta.4")]
+[assembly: AssemblyVersion("1.5.0.5")]
+[assembly: AssemblyFileVersion("1.5.0.5")]
+[assembly: AssemblyInformationalVersion("1.5.0-beta.5")]
 
 // Neutral Language
 [assembly: NeutralResourcesLanguage("en-US")]

--- a/src/EveLens.Avalonia/Views/Dialogs/SkinrViewerWindow.axaml.cs
+++ b/src/EveLens.Avalonia/Views/Dialogs/SkinrViewerWindow.axaml.cs
@@ -547,7 +547,12 @@ namespace EveLens.Avalonia.Views.Dialogs
                     .Where(e => e.Recipe != null)
                     .Select(e => e.Recipe!)
                     .ToList(),
-                () => _hubPrefs.CommunityPreviews == true);
+                () => _hubPrefs.CommunityPreviews == true,
+                // Platform capability is not engine presence: on a Mac before the
+                // Metal runtime ships (or after a declined install), only the CDN
+                // shelf can fill cards — the sidecar must not be attempted.
+                canRenderLocally: () => SkinrRuntimeInstaller.InstalledRoot() != null &&
+                                        _render.IsAvailable);
             _prerenderer.ThumbnailCaptured += (_, _) =>
                 Dispatcher.UIThread.Post(QueueMarketRefresh);
             _prerenderer.StateChanged += () =>

--- a/src/EveLens.Avalonia/Views/MainWindow.axaml.cs
+++ b/src/EveLens.Avalonia/Views/MainWindow.axaml.cs
@@ -2070,52 +2070,15 @@ namespace EveLens.Avalonia.Views
                 string currentVersion = AppServices.VelopackUpdate?.CurrentVersion
                     ?? AppServices.FileVersionInfo.FileVersion ?? "Unknown";
 
-                bool hasUpdate;
-                string pendingVersionFromGitHub = "";
-                string releaseUrl = "";
-
-                // Velopack handles Windows updates. For macOS/Linux, check GitHub API.
-                if (AppServices.VelopackUpdate?.IsInstalled == true)
-                {
-                    hasUpdate = await (AppServices.VelopackUpdate?.CheckNowAsync() ?? Task.FromResult(false));
-                }
-                else
-                {
-                    // Cross-platform: check GitHub releases API
-                    try
-                    {
-                        using var http = new System.Net.Http.HttpClient();
-                        http.DefaultRequestHeaders.UserAgent.ParseAdd("EveLens");
-                        var json = await http.GetStringAsync("https://api.github.com/repos/aliacollins/EveLens/releases");
-                        // Find first release matching our channel (or any if stable)
-                        string channel = currentVersion.Contains("-beta") ? "beta"
-                            : currentVersion.Contains("-alpha") ? "alpha" : "stable";
-
-                        foreach (System.Text.Json.JsonElement release in System.Text.Json.JsonDocument.Parse(json).RootElement.EnumerateArray())
-                        {
-                            string tag = release.GetProperty("tag_name").GetString() ?? "";
-                            bool prerelease = release.GetProperty("prerelease").GetBoolean();
-
-                            // For beta channel, check all prereleases. For stable, skip prereleases.
-                            if (channel == "stable" && prerelease) continue;
-                            if (channel == "beta" && !tag.Contains("beta")) continue;
-                            if (channel == "alpha" && !tag.Contains("alpha") && !tag.Contains("beta")) continue;
-
-                            string latestVer = tag.TrimStart('v');
-                            if (string.Compare(latestVer, currentVersion, StringComparison.OrdinalIgnoreCase) > 0)
-                            {
-                                pendingVersionFromGitHub = latestVer;
-                                releaseUrl = release.GetProperty("html_url").GetString() ?? "";
-                            }
-                            break;
-                        }
-                        hasUpdate = !string.IsNullOrEmpty(pendingVersionFromGitHub);
-                    }
-                    catch
-                    {
-                        hasUpdate = false;
-                    }
-                }
+                // One path for every platform: the service handles Velopack when
+                // installed through it, and the GitHub Releases fallback on the
+                // hand-packaged macOS/Linux builds (proper numeric version
+                // comparison lives there too — the old inline string compare
+                // ordered beta.10 before beta.4).
+                bool hasUpdate = await (AppServices.VelopackUpdate?.CheckNowAsync()
+                    ?? Task.FromResult(false));
+                string pendingVersionFromGitHub = AppServices.VelopackUpdate?.PendingVersion ?? "";
+                string releaseUrl = AppServices.VelopackUpdate?.PendingUrl ?? "";
 
                 if (hasUpdate)
                 {

--- a/src/EveLens.Common/Services/GitHubReleaseChecker.cs
+++ b/src/EveLens.Common/Services/GitHubReleaseChecker.cs
@@ -1,0 +1,153 @@
+// EveLens — Character Intelligence for EVE Online
+// Copyright © 2006-2021 EVEMon Development Team, © 2025-2026 Alia Collins
+// Built with Claude Code (Anthropic)
+// Licensed under GPL v2 — see LICENSE for details
+
+using System;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace EveLens.Common.Services
+{
+    /// <summary>A newer release found on GitHub for this build's channel.</summary>
+    public sealed class GitHubReleaseInfo
+    {
+        public string Version { get; init; } = "";
+        public string Url { get; init; } = "";
+        public string NotesMarkdown { get; init; } = "";
+    }
+
+    /// <summary>
+    /// Update checking for the platforms Velopack cannot serve: the macOS
+    /// <c>.app</c> and Linux archives are hand-packaged, so Velopack reports
+    /// "not installed" there and its whole update path is inert. This checker
+    /// asks the GitHub Releases API instead and answers one question — is there
+    /// a newer release on MY channel? — leaving the actual download to the
+    /// browser, since a zip cannot swap itself in place the way Velopack does.
+    /// </summary>
+    /// <remarks>
+    /// Version comparison is numeric on (major, minor, patch, build), never
+    /// lexicographic: string ordering says <c>beta.10 &lt; beta.4</c>, which is
+    /// exactly the kind of bug that only detonates months after shipping.
+    /// Channel comes from the informational version (<c>1.5.0-beta.4</c>); the
+    /// numeric file version carries no channel and must not be used for this.
+    /// </remarks>
+    public static class GitHubReleaseChecker
+    {
+        private const string ReleasesApi =
+            "https://api.github.com/repos/aliacollins/EveLens/releases";
+
+        internal readonly record struct ParsedVersion(
+            int Major, int Minor, int Patch, string Channel, int Build);
+
+        /// <summary>Parses <c>1.5.0</c>, <c>1.5.0-beta.4</c>, or the same with a
+        /// <c>+commit</c> suffix (SourceLink appends one to ProductVersion).</summary>
+        internal static ParsedVersion? Parse(string? version)
+        {
+            if (string.IsNullOrWhiteSpace(version))
+                return null;
+            string v = version.Trim().TrimStart('v');
+            int plus = v.IndexOf('+');
+            if (plus >= 0)
+                v = v[..plus];
+            var m = System.Text.RegularExpressions.Regex.Match(
+                v, @"^(\d+)\.(\d+)\.(\d+)(?:-(alpha|beta)\.(\d+))?$");
+            if (!m.Success)
+                return null;
+            return new ParsedVersion(
+                int.Parse(m.Groups[1].Value), int.Parse(m.Groups[2].Value),
+                int.Parse(m.Groups[3].Value),
+                m.Groups[4].Success ? m.Groups[4].Value : "stable",
+                m.Groups[5].Success ? int.Parse(m.Groups[5].Value) : 0);
+        }
+
+        /// <summary>Whether <paramref name="candidate"/> is a newer release than
+        /// <paramref name="current"/> for a user on the current build's channel.
+        /// A stable release outranks any pre-release of the same numbers.</summary>
+        internal static bool IsNewer(ParsedVersion current, ParsedVersion candidate)
+        {
+            int byNumbers = (candidate.Major, candidate.Minor, candidate.Patch)
+                .CompareTo((current.Major, current.Minor, current.Patch));
+            if (byNumbers != 0)
+                return byNumbers > 0;
+            // Same numbers: stable is the finished form of its pre-releases.
+            bool curPre = current.Channel != "stable";
+            bool candPre = candidate.Channel != "stable";
+            if (curPre && !candPre)
+                return true;
+            if (!curPre)
+                return false;
+            if (current.Channel != candidate.Channel)
+                return candidate.Channel == "beta";   // beta outranks alpha
+            return candidate.Build > current.Build;
+        }
+
+        /// <summary>Whether a release belongs to what this channel's user should
+        /// be offered: beta users take beta + stable, alpha takes everything,
+        /// stable users take only stable.</summary>
+        internal static bool ChannelAccepts(string channel, string releaseChannel) =>
+            channel switch
+            {
+                "alpha" => true,
+                "beta" => releaseChannel != "alpha",
+                _ => releaseChannel == "stable",
+            };
+
+        /// <summary>
+        /// Returns the newest release that outranks <paramref name="currentVersion"/>
+        /// on its own channel, or null when up to date or unreachable — this is a
+        /// polling path, so network trouble is a quiet "not now", never a dialog.
+        /// </summary>
+        public static async Task<GitHubReleaseInfo?> CheckAsync(
+            string? currentVersion, CancellationToken ct = default)
+        {
+            ParsedVersion? cur = Parse(currentVersion);
+            if (cur == null)
+                return null;
+            try
+            {
+                using var http = new System.Net.Http.HttpClient();
+                http.Timeout = TimeSpan.FromSeconds(20);
+                http.DefaultRequestHeaders.UserAgent.ParseAdd("EveLens");
+                string json = await http.GetStringAsync(ReleasesApi, ct)
+                    .ConfigureAwait(false);
+
+                GitHubReleaseInfo? best = null;
+                ParsedVersion bestVer = cur.Value;
+                using var doc = JsonDocument.Parse(json);
+                foreach (JsonElement release in doc.RootElement.EnumerateArray())
+                {
+                    if (release.TryGetProperty("draft", out var d) && d.GetBoolean())
+                        continue;
+                    string tag = release.GetProperty("tag_name").GetString() ?? "";
+                    ParsedVersion? rel = Parse(tag);
+                    if (rel == null || !ChannelAccepts(cur.Value.Channel, rel.Value.Channel))
+                        continue;
+                    if (!IsNewer(bestVer, rel.Value))
+                        continue;
+                    bestVer = rel.Value;
+                    best = new GitHubReleaseInfo
+                    {
+                        Version = tag.TrimStart('v'),
+                        Url = release.TryGetProperty("html_url", out var u)
+                            ? u.GetString() ?? "" : "",
+                        NotesMarkdown = release.TryGetProperty("body", out var b)
+                            ? b.GetString() ?? "" : "",
+                    };
+                }
+                return best;
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                AppServices.TraceService?.Trace(
+                    $"GitHubReleaseChecker: check failed: {ex.Message}");
+                return null;
+            }
+        }
+    }
+}

--- a/src/EveLens.Common/Services/SkinrThumbnailPrerenderer.cs
+++ b/src/EveLens.Common/Services/SkinrThumbnailPrerenderer.cs
@@ -43,18 +43,25 @@ namespace EveLens.Common.Services
         private const int IdlePollMs = 5000;
 
         private readonly Func<bool>? _communityPreviews;
+        private readonly Func<bool>? _canRenderLocally;
+        private bool _couldRenderLastPass = true;
 
         public SkinrThumbnailPrerenderer(
             SkinrThumbnailCache cache,
             Func<IReadOnlyList<EsiSkinrRecipe>> candidates,
             Func<bool>? communityPreviews = null,
-            ISkinrRecipeResolver? resolver = null)
+            ISkinrRecipeResolver? resolver = null,
+            Func<bool>? canRenderLocally = null)
         {
             _cache = cache;
             _candidates = candidates;
             _communityPreviews = communityPreviews;
+            _canRenderLocally = canRenderLocally;
             _resolver = resolver ?? AppServices.SkinrRecipeResolver;
         }
+
+        /// <summary>Designs given up on so far — a test seam, and honest bookkeeping.</summary>
+        internal int FailedCount => _failed.Count;
 
         /// <summary>Raised (off the UI thread) when a design's thumbnail lands on disk.</summary>
         public event Action<string, string>? ThumbnailCaptured;
@@ -83,6 +90,15 @@ namespace EveLens.Common.Services
             {
                 while (!ct.IsCancellationRequested)
                 {
+                    // When the local engine appears mid-session (the runtime just
+                    // installed), designs parked as "failed" because there was no
+                    // engine deserve another pass — that verdict was about the
+                    // machine, not the designs.
+                    bool canRender = _canRenderLocally?.Invoke() != false;
+                    if (canRender && !_couldRenderLastPass)
+                        _failed.Clear();
+                    _couldRenderLastPass = canRender;
+
                     EsiSkinrRecipe? next = PickNext();
                     if (next == null)
                     {
@@ -152,6 +168,19 @@ namespace EveLens.Common.Services
                     ThumbnailCaptured?.Invoke(recipe.Id, shelf);
                     return false;
                 }
+            }
+
+            // No local engine (runtime not installed — a Mac before its Metal
+            // runtime ships, or a decline on Windows): the CDN shelf above was
+            // the only possible source, so stop here. Without this gate the loop
+            // resolved every market design and attempted a sidecar per one —
+            // hundreds of doomed attempts that made the whole window feel busy
+            // (user-reported on macOS). The failed set is cleared the moment an
+            // engine appears, so these designs get their render then.
+            if (_canRenderLocally?.Invoke() == false)
+            {
+                _failed.Add(recipe.Id);
+                return false;
             }
 
             if (!_resolver.IsAvailable)

--- a/src/EveLens.Common/Services/VelopackUpdateService.cs
+++ b/src/EveLens.Common/Services/VelopackUpdateService.cs
@@ -28,13 +28,27 @@ namespace EveLens.Common.Services
         private readonly IDispatcher? _dispatcher;
         private CancellationTokenSource? _cts;
         private VelopackUpdateInfo? _pendingUpdate;
+        private GitHubReleaseInfo? _pendingGitHub;
         private bool _disposed;
 
         /// <summary>Whether the Velopack VelopackUpdateManager reports this is an installed app (not portable/dev).</summary>
         public bool IsInstalled => _manager.IsInstalled;
 
-        /// <summary>The current app version as reported by Velopack.</summary>
-        public string? CurrentVersion => _manager.CurrentVersion?.ToString();
+        /// <summary>The current app version: Velopack's when installed through it,
+        /// otherwise the informational version (which carries the -beta/-alpha
+        /// channel; the numeric file version does not and misclassifies builds).</summary>
+        public string? CurrentVersion => _manager.CurrentVersion?.ToString()
+            ?? AppServices.FileVersionInfo.ProductVersion;
+
+        /// <summary>
+        /// The hand-packaged platforms: the macOS .app and Linux archives are not
+        /// Velopack installs, so Velopack sits inert there. Updates on these
+        /// platforms mean "tell the user and open the release page" — an archive
+        /// cannot swap itself in place — via <see cref="GitHubReleaseChecker"/>.
+        /// </summary>
+        public bool UsesGitHubFallback =>
+            !_manager.IsInstalled &&
+            (OperatingSystem.IsMacOS() || OperatingSystem.IsLinux());
 
         /// <summary>The update channel this build belongs to (derived from version).</summary>
         public string Channel => CurrentVersion?.Contains("-alpha") == true ? "alpha"
@@ -51,14 +65,20 @@ namespace EveLens.Common.Services
             _ => TimeSpan.FromHours(6)
         };
 
-        /// <summary>Whether an update has been downloaded and is ready to apply.</summary>
-        public bool IsUpdateReady => _pendingUpdate != null;
+        /// <summary>Whether an update is pending (downloaded, or found on GitHub).</summary>
+        public bool IsUpdateReady => _pendingUpdate != null || _pendingGitHub != null;
 
         /// <summary>Version string of the pending update, or null.</summary>
-        public string? PendingVersion => _pendingUpdate?.TargetFullRelease?.Version?.ToString();
+        public string? PendingVersion => _pendingUpdate?.TargetFullRelease?.Version?.ToString()
+            ?? _pendingGitHub?.Version;
 
         /// <summary>Release notes (markdown) for the pending update, from the GitHub Release body.</summary>
-        public string? PendingReleaseNotes => _pendingUpdate?.TargetFullRelease?.NotesMarkdown;
+        public string? PendingReleaseNotes => _pendingUpdate?.TargetFullRelease?.NotesMarkdown
+            ?? _pendingGitHub?.NotesMarkdown;
+
+        /// <summary>Release page for a GitHub-fallback update, or null on Velopack
+        /// installs (which download and apply themselves).</summary>
+        public string? PendingUrl => _pendingGitHub?.Url;
 
         public VelopackUpdateService(
             IEventAggregator? eventAggregator = null,
@@ -76,7 +96,7 @@ namespace EveLens.Common.Services
         /// </summary>
         public void StartBackgroundChecks()
         {
-            if (_disposed || !_manager.IsInstalled)
+            if (_disposed || (!_manager.IsInstalled && !UsesGitHubFallback))
                 return;
 
             _cts = new CancellationTokenSource();
@@ -92,8 +112,25 @@ namespace EveLens.Common.Services
             {
                 if (!_manager.IsInstalled)
                 {
-                    AppServices.TraceService?.Trace("VelopackUpdate: Not installed (dev mode), skipping check");
-                    return false;
+                    if (!UsesGitHubFallback)
+                    {
+                        AppServices.TraceService?.Trace(
+                            "VelopackUpdate: Not installed (dev mode), skipping check");
+                        return false;
+                    }
+                    GitHubReleaseInfo? gh = await GitHubReleaseChecker
+                        .CheckAsync(CurrentVersion).ConfigureAwait(false);
+                    if (gh == null)
+                    {
+                        AppServices.TraceService?.Trace(
+                            "VelopackUpdate: GitHub check — no newer release");
+                        return false;
+                    }
+                    AppServices.TraceService?.Trace(
+                        $"VelopackUpdate: GitHub release available: {gh.Version}");
+                    _pendingGitHub = gh;
+                    PublishGitHubUpdateAvailable(gh);
+                    return true;
                 }
 
                 AppServices.TraceService?.Trace("VelopackUpdate: Checking for updates...");
@@ -209,6 +246,24 @@ namespace EveLens.Common.Services
             {
                 AppServices.TraceService?.Trace($"VelopackUpdate: Background loop error: {ex.Message}");
             }
+        }
+
+        private void PublishGitHubUpdateAvailable(GitHubReleaseInfo info)
+        {
+            var notification = new Notifications.NotificationEventArgs(
+                null, Notifications.NotificationCategory.QueryingError)
+            {
+                // An archive cannot swap itself in place, so the honest promise
+                // is a download, not a restart.
+                Description =
+                    $"EveLens {info.Version} is available. Help > Check for Updates to download.",
+                Behaviour = Notifications.NotificationBehaviour.Overwrite,
+                Priority = Notifications.NotificationPriority.Information
+            };
+            if (_dispatcher != null)
+                _dispatcher.Post(() => AppServices.Notifications?.Notify(notification));
+            else
+                AppServices.Notifications?.Notify(notification);
         }
 
         private void PublishUpdateAvailable(VelopackUpdateInfo info)

--- a/tests/EveLens.Tests/Services/GitHubReleaseCheckerTests.cs
+++ b/tests/EveLens.Tests/Services/GitHubReleaseCheckerTests.cs
@@ -1,0 +1,72 @@
+// EveLens — Character Intelligence for EVE Online
+// Copyright © 2006-2021 EVEMon Development Team, © 2025-2026 Alia Collins
+// Built with Claude Code (Anthropic)
+// Licensed under GPL v2 — see LICENSE for details
+
+using EveLens.Common.Services;
+using FluentAssertions;
+using Xunit;
+
+namespace EveLens.Tests.Services
+{
+    /// <summary>
+    /// The mac/linux update path compares versions numerically. The inline code
+    /// it replaced compared strings, which orders beta.10 before beta.4 and read
+    /// the channel off the numeric file version (which has none) — both bugs
+    /// that only detonate later. These tests pin the correct behavior.
+    /// </summary>
+    public sealed class GitHubReleaseCheckerTests
+    {
+        [Theory]
+        [InlineData("1.5.0-beta.4", 1, 5, 0, "beta", 4)]
+        [InlineData("v1.5.0-beta.4", 1, 5, 0, "beta", 4)]
+        [InlineData("1.5.0", 1, 5, 0, "stable", 0)]
+        [InlineData("1.5.0-alpha.12", 1, 5, 0, "alpha", 12)]
+        [InlineData("1.5.0-beta.4+abc123", 1, 5, 0, "beta", 4)] // SourceLink suffix
+        public void Parse_ReadsEveryShapeWeStamp(string input, int major, int minor,
+            int patch, string channel, int build)
+        {
+            var v = GitHubReleaseChecker.Parse(input);
+            v.Should().NotBeNull();
+            (v!.Value.Major, v.Value.Minor, v.Value.Patch, v.Value.Channel, v.Value.Build)
+                .Should().Be((major, minor, patch, channel, build));
+        }
+
+        [Theory]
+        [InlineData("1.5.0.4")]      // numeric file version carries no channel
+        [InlineData("")]
+        [InlineData("not-a-version")]
+        public void Parse_RejectsWhatIsNotAReleaseVersion(string input) =>
+            GitHubReleaseChecker.Parse(input).Should().BeNull();
+
+        [Theory]
+        [InlineData("1.5.0-beta.4", "1.5.0-beta.10", true)]  // THE string-compare bug
+        [InlineData("1.5.0-beta.10", "1.5.0-beta.4", false)]
+        [InlineData("1.5.0-beta.4", "1.5.0-beta.4", false)]
+        [InlineData("1.5.0-beta.4", "1.5.0", true)]          // stable finishes its betas
+        [InlineData("1.5.0", "1.5.0-beta.9", false)]         // never downgrade to a pre
+        [InlineData("1.5.0", "1.5.1", true)]
+        [InlineData("1.5.0-alpha.3", "1.5.0-beta.1", true)]  // beta outranks alpha
+        [InlineData("1.4.9", "1.5.0-beta.1", true)]
+        public void IsNewer_ComparesNumbersNotStrings(string current, string candidate,
+            bool expected)
+        {
+            GitHubReleaseChecker.IsNewer(
+                    GitHubReleaseChecker.Parse(current)!.Value,
+                    GitHubReleaseChecker.Parse(candidate)!.Value)
+                .Should().Be(expected, $"{candidate} vs {current}");
+        }
+
+        [Theory]
+        [InlineData("stable", "stable", true)]
+        [InlineData("stable", "beta", false)]
+        [InlineData("beta", "beta", true)]
+        [InlineData("beta", "stable", true)]   // beta users take the finished release
+        [InlineData("beta", "alpha", false)]
+        [InlineData("alpha", "alpha", true)]
+        [InlineData("alpha", "stable", true)]
+        public void ChannelAccepts_OffersOnlyWhatTheChannelShouldSee(string channel,
+            string release, bool expected) =>
+            GitHubReleaseChecker.ChannelAccepts(channel, release).Should().Be(expected);
+    }
+}

--- a/tests/EveLens.Tests/Services/SkinrThumbnailPrerendererTests.cs
+++ b/tests/EveLens.Tests/Services/SkinrThumbnailPrerendererTests.cs
@@ -1,0 +1,64 @@
+// EveLens — Character Intelligence for EVE Online
+// Copyright © 2006-2021 EVEMon Development Team, © 2025-2026 Alia Collins
+// Built with Claude Code (Anthropic)
+// Licensed under GPL v2 — see LICENSE for details
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using EveLens.Common.Interfaces;
+using EveLens.Common.Services;
+using EveLens.Common.Serialization.Esi;
+using FluentAssertions;
+using NSubstitute;
+using Xunit;
+
+namespace EveLens.Tests.Services
+{
+    /// <summary>
+    /// Regression for the Mac busy-loop: with the platform flagged Supported but
+    /// no runtime installed, the prerenderer resolved every market design and
+    /// attempted a sidecar per one — hundreds of doomed attempts that made the
+    /// window unusable. Without a local engine it must park designs quietly and
+    /// never touch the resolver or the sidecar.
+    /// </summary>
+    public sealed class SkinrThumbnailPrerendererTests : IDisposable
+    {
+        private readonly string _dir = Path.Combine(Path.GetTempPath(),
+            "evelens-thumbs-" + Guid.NewGuid().ToString("N"));
+
+        public void Dispose()
+        {
+            try { Directory.Delete(_dir, recursive: true); }
+            catch (Exception) { /* temp dir */ }
+        }
+
+        [Fact]
+        public async Task WithoutALocalEngine_ParksDesignsWithoutResolvingOrRendering()
+        {
+            var resolver = Substitute.For<ISkinrRecipeResolver>();
+            var recipes = new List<EsiSkinrRecipe>
+            {
+                new() { Id = "design-a" },
+                new() { Id = "design-b" },
+            };
+            using var sut = new SkinrThumbnailPrerenderer(
+                new SkinrThumbnailCache(_dir),
+                () => recipes,
+                communityPreviews: () => false,
+                resolver: resolver,
+                canRenderLocally: () => false);
+
+            sut.Start();
+            // The loop marks each design once (100ms cadence); give it room.
+            for (int i = 0; i < 100 && sut.FailedCount < 2; i++)
+                await Task.Delay(50);
+
+            sut.FailedCount.Should().Be(2,
+                "both designs must be parked exactly once, not retried forever");
+            sut.Rendered.Should().Be(0);
+            resolver.DidNotReceiveWithAnyArgs().Resolve(default!);
+        }
+    }
+}

--- a/updates/evelens-patch-beta.xml
+++ b/updates/evelens-patch-beta.xml
@@ -7,6 +7,16 @@
   <releases>
     <release>
       <date>2026-08-26</date>
+      <version>1.5.0.5</version>
+      <url>https://github.com/aliacollins/evelens/releases/tag/beta</url>
+      <autopatchurl>https://github.com/aliacollins/evelens/releases/download/beta/EveLens-install-1.5.0.exe</autopatchurl>
+      <autopatchargs>/SILENT</autopatchargs>
+      <message><![CDATA[EveLens 1.5.0-beta.5
+
+Beta 5: Mac SKINR usable without the renderer; macOS/Linux update checks]]></message>
+    </release>
+    <release>
+      <date>2026-08-26</date>
       <version>1.5.0.4</version>
       <url>https://github.com/aliacollins/evelens/releases/tag/beta</url>
       <autopatchurl>https://github.com/aliacollins/evelens/releases/download/beta/EveLens-install-1.5.0.exe</autopatchurl>
@@ -94,16 +104,6 @@ Non-Windows stability: crash backstop, GDI+ default-image fix, SSO token error c
       <message><![CDATA[EveLens 1.4.0-beta.4
 
 i18n architecture: data-file UI strings, LanguageRegistry, {loc:T} markup, .LocalizedName fixes everywhere, market-group SDE names; ~300 strings migrated]]></message>
-    </release>
-    <release>
-      <date>2026-06-03</date>
-      <version>1.4.0.3</version>
-      <url>https://github.com/aliacollins/evelens/releases/tag/beta</url>
-      <autopatchurl>https://github.com/aliacollins/evelens/releases/download/beta/EveLens-install-1.4.0.exe</autopatchurl>
-      <autopatchargs>/SILENT</autopatchargs>
-      <message><![CDATA[EveLens 1.4.0-beta.3
-
-Korean (ko) language support: 464 UI strings + 50K SDE names (Discussion #79)]]></message>
     </release>
   </releases>
   <datafiles>


### PR DESCRIPTION
Automated promotion: experimental/skinr -> beta (1.5.0-beta.5)

Beta 5: Mac SKINR usable without the renderer; macOS/Linux update checks