### PR TITLE
Beta 1.5.0-beta.8: Beta 8: overview sort/reorder controls appear when the second character arrives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Sort and reorder controls appear when the second character arrives** -- The overview's sort, density, and reorder controls only exist with 2+ characters, but adding the second character took the incremental card-update path that never re-evaluates the toolbar -- so the controls stayed hidden until an app restart. Crossing the threshold (either direction) now rebuilds the header.
+
 ## [1.5.0-beta.7] - 2026-08-26
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.5.0-beta.7] - 2026-08-26
+
 ### Fixed
 
 - **Status strip no longer prints your file paths** -- When the 3D engine is missing, the SKINR status line showed the renderer's full internal search report: environment variable names and local filesystem paths. That report belongs in the diagnostic log (where it still goes, complete); the interface now says one plain sentence.

--- a/SharedAssemblyInfo.cs
+++ b/SharedAssemblyInfo.cs
@@ -30,9 +30,9 @@ using System.Runtime.InteropServices;
 //      Build Number
 //      Revision (0 for stable, 1+ for beta)
 //
-[assembly: AssemblyVersion("1.5.0.7")]
-[assembly: AssemblyFileVersion("1.5.0.7")]
-[assembly: AssemblyInformationalVersion("1.5.0-beta.7")]
+[assembly: AssemblyVersion("1.5.0.8")]
+[assembly: AssemblyFileVersion("1.5.0.8")]
+[assembly: AssemblyInformationalVersion("1.5.0-beta.8")]
 
 // Neutral Language
 [assembly: NeutralResourcesLanguage("en-US")]

--- a/src/EveLens.Avalonia/Views/CharacterMonitor/CharacterOverviewView.axaml.cs
+++ b/src/EveLens.Avalonia/Views/CharacterMonitor/CharacterOverviewView.axaml.cs
@@ -60,6 +60,7 @@ namespace EveLens.Avalonia.Views.CharacterMonitor
         // Reorder mode — when active, cards are draggable instead of clickable
         private bool _reorderMode;
         private Button? _reorderToggleBtn;
+        private DockPanel? _reorderToolbar;
 
         // Only animate the staggered fade-in on first application load
         private bool _initialLoadDone;
@@ -1225,6 +1226,21 @@ namespace EveLens.Avalonia.Views.CharacterMonitor
                 }
 
                 var currentChars = AppServices.Characters.Where(c => c.Monitored).ToList();
+
+                // The sort/reorder/density toolbar exists only at 2+ characters,
+                // and this incremental path only touches CARDS. When the count
+                // crosses that boundary (adding the second character, or dropping
+                // back to one), the toolbar's existence-condition changed — full
+                // rebuild, or the controls only appear after an app restart
+                // (user-reported).
+                bool toolbarShown = _reorderToolbar != null &&
+                                    OverviewPanel.Children.Contains(_reorderToolbar);
+                if (currentChars.Count >= 2 != toolbarShown)
+                {
+                    LoadData();
+                    return;
+                }
+
                 var existingCards = GetAllCardButtons().ToList();
                 var existingIds = new HashSet<long>(
                     existingCards
@@ -1656,6 +1672,7 @@ namespace EveLens.Avalonia.Views.CharacterMonitor
             _reorderToggleBtn.Click += OnReorderToggle;
 
             var toolbar = new DockPanel { Margin = new Thickness(0, 0, 0, 4) };
+            _reorderToolbar = toolbar;
             if (_reorderMode)
             {
                 // Teach the full gesture set while the mode where they work is active

--- a/updates/evelens-patch-beta.xml
+++ b/updates/evelens-patch-beta.xml
@@ -7,6 +7,16 @@
   <releases>
     <release>
       <date>2026-08-26</date>
+      <version>1.5.0.8</version>
+      <url>https://github.com/aliacollins/evelens/releases/tag/beta</url>
+      <autopatchurl>https://github.com/aliacollins/evelens/releases/download/beta/EveLens-install-1.5.0.exe</autopatchurl>
+      <autopatchargs>/SILENT</autopatchargs>
+      <message><![CDATA[EveLens 1.5.0-beta.8
+
+Beta 8: overview sort/reorder controls appear when the second character arrives]]></message>
+    </release>
+    <release>
+      <date>2026-08-26</date>
       <version>1.5.0.7</version>
       <url>https://github.com/aliacollins/evelens/releases/tag/beta</url>
       <autopatchurl>https://github.com/aliacollins/evelens/releases/download/beta/EveLens-install-1.5.0.exe</autopatchurl>
@@ -94,16 +104,6 @@ net10 + Avalonia 12 + SkiaSharp 3 -- first 1.5.0 beta]]></message>
       <message><![CDATA[EveLens 1.4.0-beta.7
 
 1.4.1 corrective: full 1.4.0 content train plus promote-script content verification]]></message>
-    </release>
-    <release>
-      <date>2026-08-10</date>
-      <version>1.4.0.6</version>
-      <url>https://github.com/aliacollins/evelens/releases/tag/beta</url>
-      <autopatchurl>https://github.com/aliacollins/evelens/releases/download/beta/EveLens-install-1.4.0.exe</autopatchurl>
-      <autopatchargs>/SILENT</autopatchargs>
-      <message><![CDATA[EveLens 1.4.0-beta.6
-
-1.4.0-beta.5: community fix train, SDE 3458726, Attribute Optimizer, EVE Accuracy Suite, auto-update opt-in]]></message>
     </release>
   </releases>
   <datafiles>


### PR DESCRIPTION
Automated promotion: experimental/skinr -> beta (1.5.0-beta.8)

Beta 8: overview sort/reorder controls appear when the second character arrives