### PR TITLE
Beta 1.5.0-beta.12: Overview account badge no longer clips at large font scales

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **The Omega/Alpha badge on overview cards no longer clips at large font sizes** -- The badge's column was sized to the portrait's pixel width, which the badge text outgrows the moment the font scale passes 110%. The column now follows its content, so the badge fits at every scale and in every language (#72).
+
 ## [1.5.0-beta.11] - 2026-08-27
 
 ### Fixed

--- a/SharedAssemblyInfo.cs
+++ b/SharedAssemblyInfo.cs
@@ -30,9 +30,9 @@ using System.Runtime.InteropServices;
 //      Build Number
 //      Revision (0 for stable, 1+ for beta)
 //
-[assembly: AssemblyVersion("1.5.0.11")]
-[assembly: AssemblyFileVersion("1.5.0.11")]
-[assembly: AssemblyInformationalVersion("1.5.0-beta.11")]
+[assembly: AssemblyVersion("1.5.0.12")]
+[assembly: AssemblyFileVersion("1.5.0.12")]
+[assembly: AssemblyInformationalVersion("1.5.0-beta.12")]
 
 // Neutral Language
 [assembly: NeutralResourcesLanguage("en-US")]

--- a/src/EveLens.Avalonia/Views/CharacterMonitor/CharacterOverviewView.axaml.cs
+++ b/src/EveLens.Avalonia/Views/CharacterMonitor/CharacterOverviewView.axaml.cs
@@ -892,7 +892,11 @@ namespace EveLens.Avalonia.Views.CharacterMonitor
             // Add Omega/Alpha badge below portrait
             portraitContainer.Children.Add(badge);
 
-            var cardGrid = new Grid { ColumnDefinitions = ColumnDefinitions.Parse("68,*") };
+            // Auto, not a fixed 68: the column's natural floor is the 56px portrait +
+            // 12px margin (identical at default scale), but the badge under it renders
+            // "Ω Omega" at a user-chosen font scale, and a column sized to the portrait
+            // alone clips the badge the moment text outgrows it (#72).
+            var cardGrid = new Grid { ColumnDefinitions = ColumnDefinitions.Parse("Auto,*") };
             Grid.SetColumn(portraitContainer, 0);
             Grid.SetColumn(infoPanel, 1);
             cardGrid.Children.Add(portraitContainer);

--- a/tests/EveLens.Tests/Architecture/FontScaleArchitectureTests.cs
+++ b/tests/EveLens.Tests/Architecture/FontScaleArchitectureTests.cs
@@ -99,6 +99,23 @@ namespace EveLens.Tests.Architecture
         }
 
         [Fact]
+        public void OverviewCard_PortraitColumn_SizesToContent()
+        {
+            // The account-status badge ("Ω Omega") sits under the portrait and renders
+            // at a user-chosen font scale. A column fixed to the portrait's pixel width
+            // clips the badge the moment text outgrows it (#72) — the column must be
+            // Auto so it follows its widest child at every scale and in every language.
+            var file = Path.Combine(ViewsDir, "CharacterMonitor", "CharacterOverviewView.axaml.cs");
+            if (!File.Exists(file))
+                return;
+
+            var content = File.ReadAllText(file);
+            Regex.IsMatch(content, @"ColumnDefinitions\.Parse\(""\d+,").Should().BeFalse(
+                "the overview card's portrait column must be Auto-sized, not a fixed pixel " +
+                "width — fixed widths clip the scaled account badge (#72)");
+        }
+
+        [Fact]
         public void AllPalettes_DefineFontResources()
         {
             var palettesDir = Path.Combine(ThemesDir, "Palettes");

--- a/updates/evelens-patch-beta.xml
+++ b/updates/evelens-patch-beta.xml
@@ -7,6 +7,16 @@
   <releases>
     <release>
       <date>2026-08-27</date>
+      <version>1.5.0.12</version>
+      <url>https://github.com/aliacollins/evelens/releases/tag/beta</url>
+      <autopatchurl>https://github.com/aliacollins/evelens/releases/download/beta/EveLens-install-1.5.0.exe</autopatchurl>
+      <autopatchargs>/SILENT</autopatchargs>
+      <message><![CDATA[EveLens 1.5.0-beta.12
+
+Overview account badge no longer clips at large font scales]]></message>
+    </release>
+    <release>
+      <date>2026-08-27</date>
       <version>1.5.0.11</version>
       <url>https://github.com/aliacollins/evelens/releases/tag/beta</url>
       <autopatchurl>https://github.com/aliacollins/evelens/releases/download/beta/EveLens-install-1.5.0.exe</autopatchurl>
@@ -92,16 +102,6 @@ Beta 4: Mac SKINR shows honest renderer-coming state on every path]]></message>
       <autopatchurl>https://github.com/aliacollins/evelens/releases/download/beta/EveLens-install-1.5.0.exe</autopatchurl>
       <autopatchargs>/SILENT</autopatchargs>
       <message><![CDATA[EveLens 1.5.0-beta.3
-
-Beta 3: SKINR geometry converter ships inside Render Runtime 1.0.3; runtime updates in place]]></message>
-    </release>
-    <release>
-      <date>2026-08-26</date>
-      <version>1.5.0.1</version>
-      <url>https://github.com/aliacollins/evelens/releases/tag/beta</url>
-      <autopatchurl>https://github.com/aliacollins/evelens/releases/download/beta/EveLens-install-1.5.0.exe</autopatchurl>
-      <autopatchargs>/SILENT</autopatchargs>
-      <message><![CDATA[EveLens 1.5.0-beta.1
 
 Beta 3: SKINR geometry converter ships inside Render Runtime 1.0.3; runtime updates in place]]></message>
     </release>


### PR DESCRIPTION
Automated promotion: experimental/skinr -> beta (1.5.0-beta.12)

Overview account badge no longer clips at large font scales