### PR TITLE
Beta 1.5.0-beta.14: Mac single-file startup fix; supercapitals lose the Hangar preset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,15 @@ All notable changes to EveLens will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.5.0-beta.14] - 2026-08-28
+
+### Changed
+
+- **Supercapitals no longer offer a Hangar environment at all** -- beta.13 greyed the Hangar pill out for titans and supercarriers with a "coming later" tooltip; the honest answer is simpler. No station bay is authored at that scale, so for supercapital hulls the pill is now gone entirely -- Studio, Space, Sunlight and Beauty remain -- and every other ship keeps the full set. If a super arrives while the hangar is showing, the stage still returns to Studio on its own.
+
+### Fixed
+
+- **macOS: the app opens again** -- beta.13's macOS build was our first single-file bundle (Apple's notarization rules effectively require it), and a single-file app reports no on-disk location for itself. EveLens read its own version from that location on startup, so it quit before the first window could appear. The version now comes from metadata compiled into the binary, which works in every publish shape on every platform. Windows and Linux were never affected.
 
 ## [1.5.0-beta.13] - 2026-08-28
 

--- a/SharedAssemblyInfo.cs
+++ b/SharedAssemblyInfo.cs
@@ -30,9 +30,9 @@ using System.Runtime.InteropServices;
 //      Build Number
 //      Revision (0 for stable, 1+ for beta)
 //
-[assembly: AssemblyVersion("1.5.0.13")]
-[assembly: AssemblyFileVersion("1.5.0.13")]
-[assembly: AssemblyInformationalVersion("1.5.0-beta.13")]
+[assembly: AssemblyVersion("1.5.0.14")]
+[assembly: AssemblyFileVersion("1.5.0.14")]
+[assembly: AssemblyInformationalVersion("1.5.0-beta.14")]
 
 // Neutral Language
 [assembly: NeutralResourcesLanguage("en-US")]

--- a/src/EveLens.Avalonia/App.axaml.cs
+++ b/src/EveLens.Avalonia/App.axaml.cs
@@ -279,7 +279,7 @@ namespace EveLens.Avalonia
 
         private async Task ShowWhatsNewIfNeededAsync()
         {
-            var currentVersion = AppServices.FileVersionInfo?.ProductVersion ?? "";
+            var currentVersion = AppServices.AppVersion.ProductVersion ?? "";
             AppServices.TraceService?.Trace(
                 $"WhatsNew: version='{currentVersion}' lastShown='{Settings.Updates.LastShownWhatsNewVersion}'",
                 printMethod: false);

--- a/src/EveLens.Avalonia/Views/Dialogs/AboutWindow.axaml.cs
+++ b/src/EveLens.Avalonia/Views/Dialogs/AboutWindow.axaml.cs
@@ -79,7 +79,7 @@ namespace EveLens.Avalonia.Views.Dialogs
         {
             try
             {
-                var fvi = AppServices.FileVersionInfo;
+                var fvi = AppServices.AppVersion;
                 string version = AppServices.IsDebugBuild
                     ? $"{fvi.FileVersion} (Debug)"
                     : fvi.ProductVersion ?? fvi.FileVersion ?? "Unknown";

--- a/src/EveLens.Avalonia/Views/Dialogs/SkinrViewerWindow.axaml.cs
+++ b/src/EveLens.Avalonia/Views/Dialogs/SkinrViewerWindow.axaml.cs
@@ -2103,9 +2103,10 @@ namespace EveLens.Avalonia.Views.Dialogs
         // --- overlays ------------------------------------------------------------
 
         /// <summary>
-        /// Enables/disables the Hangar pill for the staged hull. Supercapitals get
-        /// a tooltip and, if they arrive while the hangar is showing, an automatic
-        /// retreat to Studio — never a titan clipping through the bay's architecture.
+        /// Shows/hides the Hangar pill for the staged hull. Supercapitals have no
+        /// hangar look at all — the pill disappears rather than sit disabled — and
+        /// if one arrives while the hangar is showing, the view retreats to Studio,
+        /// never a titan clipping through the bay's architecture.
         /// </summary>
         private void ApplyHangarGate()
         {
@@ -2116,8 +2117,7 @@ namespace EveLens.Avalonia.Views.Dialogs
                     button.Tag is not SkinrEnvironmentPreset preset ||
                     preset != SkinrEnvironmentPreset.Hangar)
                     continue;
-                button.IsEnabled = fits;
-                ToolTip.SetTip(button, fits ? null : Loc.Get("Skinr.HangarTooBig"));
+                button.IsVisible = fits;
             }
             if (!fits && _hub.Environment == SkinrEnvironmentPreset.Hangar)
                 _ = OnEnvironmentPicked(SkinrEnvironmentPreset.Studio);

--- a/src/EveLens.Avalonia/Views/Dialogs/WhatsNewWindow.axaml.cs
+++ b/src/EveLens.Avalonia/Views/Dialogs/WhatsNewWindow.axaml.cs
@@ -51,7 +51,7 @@ namespace EveLens.Avalonia.Views.Dialogs
                 FontWeight = FontWeight.Bold,
                 Foreground = FindBrush("EveAccentPrimaryBrush")
             });
-            var ver = AppServices.FileVersionInfo?.ProductVersion ?? "";
+            var ver = AppServices.AppVersion.ProductVersion ?? "";
             headerPanel.Children.Add(new TextBlock
             {
                 Text = $"Here's what's new in EveLens {ver}",
@@ -184,7 +184,7 @@ namespace EveLens.Avalonia.Views.Dialogs
         {
             // Strategy: try to match current version to a changelog section.
             // If no match found, use [Unreleased] (we're on a dev/beta branch).
-            var version = AppServices.FileVersionInfo?.ProductVersion ?? "";
+            var version = AppServices.AppVersion.ProductVersion ?? "";
             var versionBase = version.Split('-')[0]; // "1.3.0-beta.3" -> "1.3.0"
             bool isPreRelease = version.Contains("alpha") || version.Contains("beta");
 

--- a/src/EveLens.Avalonia/Views/MainWindow.axaml.cs
+++ b/src/EveLens.Avalonia/Views/MainWindow.axaml.cs
@@ -799,7 +799,7 @@ namespace EveLens.Avalonia.Views
                 {
                     var svc = AppServices.VelopackUpdate;
                     bool installed = svc?.IsInstalled ?? false;
-                    string version = svc?.CurrentVersion ?? AppServices.FileVersionInfo.FileVersion ?? "dev";
+                    string version = svc?.CurrentVersion ?? AppServices.AppVersion.FileVersion ?? "dev";
                     string channel = svc?.Channel ?? "unknown";
                     string checkInterval = svc?.CheckInterval.TotalHours.ToString("0.#") + "h";
 
@@ -2068,7 +2068,7 @@ namespace EveLens.Avalonia.Views
             try
             {
                 string currentVersion = AppServices.VelopackUpdate?.CurrentVersion
-                    ?? AppServices.FileVersionInfo.FileVersion ?? "Unknown";
+                    ?? AppServices.AppVersion.FileVersion ?? "Unknown";
 
                 // One path for every platform: the service handles Velopack when
                 // installed through it, and the GitHub Releases fallback on the

--- a/src/EveLens.Common/CloudStorageServices/CloudStorageServiceProvider.cs
+++ b/src/EveLens.Common/CloudStorageServices/CloudStorageServiceProvider.cs
@@ -574,7 +574,7 @@ namespace EveLens.Common.CloudStorageServices
             if (configFileParentParentDir.Parent == null || !Directory.Exists(configFileParentParentDir.Parent.FullName))
                 return;
 
-            string? productName = AppServices.FileVersionInfo.ProductName;
+            string? productName = AppServices.AppVersion.ProductName;
             foreach (string directory in Directory.GetDirectories(configFileParentParentDir.Parent.FullName)
                 .Where(directory => directory != configFileParentParentDir.FullName &&
                                     productName != null &&

--- a/src/EveLens.Common/CloudStorageServices/GoogleDrive/GoogleDriveCloudStorageServiceProvider.cs
+++ b/src/EveLens.Common/CloudStorageServices/GoogleDrive/GoogleDriveCloudStorageServiceProvider.cs
@@ -425,7 +425,7 @@ namespace EveLens.Common.CloudStorageServices.GoogleDrive
             var initializer = new BaseClientService.Initializer
             {
                 HttpClientInitializer = s_credential,
-                ApplicationName = AppServices.FileVersionInfo.ProductName,
+                ApplicationName = AppServices.AppVersion.ProductName,
             };
 
             return new DriveService(initializer);

--- a/src/EveLens.Common/EveLensClient.cs
+++ b/src/EveLens.Common/EveLensClient.cs
@@ -20,6 +20,7 @@ using EveLens.Common.Models;
 using EveLens.Common.Models.Extended;
 using EveLens.Common.Net;
 using EveLens.Common.Services;
+using EveLens.Core.Interfaces;
 using Microsoft.Extensions.Logging;
 
 namespace EveLens.Common
@@ -209,19 +210,17 @@ namespace EveLens.Common
         #region Version
 
         /// <summary>
-        /// Gets the file version information.
+        /// The app's own identity, read from assembly attributes. Never from a file on
+        /// disk: a single-file publish reports an empty <c>Assembly.Location</c>, and
+        /// asking the filesystem for the version of a file that isn't there threw
+        /// before the first window opened on macOS.
         /// </summary>
-        /// <value>
-        /// The file version.
-        /// </value>
-        public static FileVersionInfo FileVersionInfo
-            => FileVersionInfo.GetVersionInfo(Assembly.GetEntryAssembly()!.Location);
+        private static readonly IAppVersionInfo s_versionInfo = new AssemblyAppVersionInfo();
 
         /// <summary>
         /// Gets the full version string from AssemblyInformationalVersion (e.g., "5.2.0-alpha.1").
         /// </summary>
-        public static string VersionString
-            => FileVersionInfo.ProductVersion ?? FileVersionInfo.FileVersion ?? "0.0.0";
+        public static string VersionString => s_versionInfo.ProductVersion;
 
         /// <summary>
         /// Gets whether this is an alpha version.
@@ -251,7 +250,7 @@ namespace EveLens.Common
         {
             get
             {
-                string productName = FileVersionInfo.ProductName ?? "EveLens";
+                string productName = s_versionInfo.ProductName;
                 if (IsAlphaVersion)
                     return $"{productName} ALPHA ({VersionString})";
                 if (IsBetaVersion)

--- a/src/EveLens.Common/ExternalCalendar/GoogleCalendarEvent.cs
+++ b/src/EveLens.Common/ExternalCalendar/GoogleCalendarEvent.cs
@@ -447,7 +447,7 @@ namespace EveLens.Common.ExternalCalendar
             var initializer = new BaseClientService.Initializer
             {
                 HttpClientInitializer = s_credential,
-                ApplicationName = AppServices.FileVersionInfo.ProductName,
+                ApplicationName = AppServices.AppVersion.ProductName,
             };
 
             return new CalendarService(initializer);

--- a/src/EveLens.Common/Helpers/DiagnosticReportBuilder.cs
+++ b/src/EveLens.Common/Helpers/DiagnosticReportBuilder.cs
@@ -379,7 +379,7 @@ namespace EveLens.Common.Helpers
             string version;
             try
             {
-                version = AppServices.FileVersionInfo?.FileVersion ?? "(unknown)";
+                version = AppServices.AppVersion.FileVersion ?? "(unknown)";
             }
             catch
             {
@@ -422,7 +422,7 @@ namespace EveLens.Common.Helpers
             try
             {
                 report.Append("EveLens Version: ").AppendLine(
-                    AppServices.FileVersionInfo.FileVersion);
+                    AppServices.AppVersion.FileVersion);
             }
             catch
             {

--- a/src/EveLens.Common/Net/HttpWebClientServiceState.cs
+++ b/src/EveLens.Common/Net/HttpWebClientServiceState.cs
@@ -51,8 +51,8 @@ namespace EveLens.Common.Net
                 var architecture = Environment.Is64BitOperatingSystem
                     ? "x64"
                     : "x86";
-                var productName = AppServices.FileVersionInfo.ProductName;
-                var version = AppServices.FileVersionInfo.FileVersion;
+                var productName = AppServices.AppVersion.ProductName;
+                var version = AppServices.AppVersion.FileVersion;
 
                 // Build user agent per ESI best practices
                 // Format: AppName/Version (contact info) (OS info)

--- a/src/EveLens.Common/Resources/ui-strings-en.txt
+++ b/src/EveLens.Common/Resources/ui-strings-en.txt
@@ -1113,6 +1113,5 @@ Skinr.PhotoShort = Photo
 Skinr.SettingsShort = Settings
 PlanEditor.BookBadge = BOOK
 PlanEditor.RemapStale = remap no longer matches this block, review optimization
-Skinr.HangarTooBig = Supercapitals don’t fit this hangar — a Keepstar-scale bay is coming in a future update
 Doctrine.ShowOnlyMissing = Show only missing
 Doctrine.MissingSpFmt = {0} SP missing

--- a/src/EveLens.Common/Resources/ui-strings-ko.txt
+++ b/src/EveLens.Common/Resources/ui-strings-ko.txt
@@ -1079,6 +1079,5 @@ Skinr.PhotoShort = 사진
 Skinr.SettingsShort = 설정
 PlanEditor.BookBadge = BOOK
 PlanEditor.RemapStale = 리맵이 이 구간과 더 이상 일치하지 않습니다. 최적화를 검토하세요
-Skinr.HangarTooBig = 슈퍼캐피털은 이 격납고에 들어가지 않습니다 — 킵스타 규모의 격납고가 추후 업데이트로 제공될 예정입니다
 Doctrine.ShowOnlyMissing = 미보유 스킬만 보기
 Doctrine.MissingSpFmt = {0} SP 부족

--- a/src/EveLens.Common/Resources/ui-strings-zh-CN.txt
+++ b/src/EveLens.Common/Resources/ui-strings-zh-CN.txt
@@ -1079,6 +1079,5 @@ Skinr.PhotoShort = 拍照
 Skinr.SettingsShort = 设置
 PlanEditor.BookBadge = 书
 PlanEditor.RemapStale = 重映射已不匹配此区段，请查看优化方案
-Skinr.HangarTooBig = 超级旗舰无法停入此机库 — 希望之堡级机库将在未来更新中推出
 Doctrine.ShowOnlyMissing = 仅显示缺少的技能
 Doctrine.MissingSpFmt = 缺少 {0} SP

--- a/src/EveLens.Common/Service/ReportSubmissionService.cs
+++ b/src/EveLens.Common/Service/ReportSubmissionService.cs
@@ -46,7 +46,7 @@ namespace EveLens.Common.Service
                 string version;
                 try
                 {
-                    version = AppServices.FileVersionInfo?.FileVersion ?? "(unknown)";
+                    version = AppServices.AppVersion.FileVersion ?? "(unknown)";
                 }
                 catch
                 {

--- a/src/EveLens.Common/Services/AppServices.cs
+++ b/src/EveLens.Common/Services/AppServices.cs
@@ -249,9 +249,13 @@ namespace EveLens.Common.Services
         public static bool IsBetaVersion => EveLensClient.IsBetaVersion;
 
         /// <summary>
-        /// Gets the file version information for the application.
+        /// Gets the application's name and version, read from assembly metadata.
+        /// Filesystem-free, so it answers correctly in a single-file publish (macOS)
+        /// where there is no on-disk assembly to interrogate.
         /// </summary>
-        public static System.Diagnostics.FileVersionInfo FileVersionInfo => EveLensClient.FileVersionInfo;
+        public static IAppVersionInfo AppVersion => s_appVersion.Value;
+        private static Lazy<IAppVersionInfo> s_appVersion = new(() => new AssemblyAppVersionInfo());
+        internal static void SetAppVersion(IAppVersionInfo info) => s_appVersion = new(() => info);
 
         /// <summary>
         /// Gets the product name with version string.

--- a/src/EveLens.Common/Services/AssemblyAppVersionInfo.cs
+++ b/src/EveLens.Common/Services/AssemblyAppVersionInfo.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Reflection;
+using EveLens.Core.Interfaces;
+
+namespace EveLens.Common.Services
+{
+    /// <summary>
+    /// Reads the app's identity from compiled-in assembly attributes. No filesystem
+    /// access, so it works identically in framework-dependent, self-contained and
+    /// single-file publishes.
+    /// </summary>
+    public sealed class AssemblyAppVersionInfo : IAppVersionInfo
+    {
+        private readonly Assembly m_assembly;
+
+        /// <summary>
+        /// Creates version info over the entry assembly, falling back to the assembly
+        /// this type lives in. The fallback matters for test hosts and for any host
+        /// that loads us without being an entry point.
+        /// </summary>
+        public AssemblyAppVersionInfo()
+            : this(Assembly.GetEntryAssembly() ?? typeof(AssemblyAppVersionInfo).Assembly)
+        {
+        }
+
+        /// <summary>Creates version info over a specific assembly.</summary>
+        public AssemblyAppVersionInfo(Assembly assembly)
+        {
+            m_assembly = assembly ?? throw new ArgumentNullException(nameof(assembly));
+        }
+
+        /// <inheritdoc />
+        public string ProductName =>
+            Attr<AssemblyProductAttribute>(a => a.Product, "EveLens");
+
+        /// <inheritdoc />
+        public string ProductVersion => StripBuildMetadata(
+            Attr<AssemblyInformationalVersionAttribute>(a => a.InformationalVersion, FileVersion));
+
+        /// <inheritdoc />
+        public string FileVersion =>
+            Attr<AssemblyFileVersionAttribute>(a => a.Version,
+                m_assembly.GetName().Version?.ToString() ?? "0.0.0.0");
+
+        /// <inheritdoc />
+        public string Company =>
+            Attr<AssemblyCompanyAttribute>(a => a.Company, "EveLens");
+
+        /// <inheritdoc />
+        public string Copyright =>
+            Attr<AssemblyCopyrightAttribute>(a => a.Copyright, string.Empty);
+
+        private string Attr<T>(Func<T, string?> read, string fallback) where T : Attribute
+        {
+            string? value = null;
+            try
+            {
+                T? attribute = m_assembly.GetCustomAttribute<T>();
+                if (attribute != null)
+                    value = read(attribute);
+            }
+            catch (Exception)
+            {
+                // A missing or malformed attribute must never be fatal — this type is
+                // read during startup, before any error UI exists.
+            }
+            return string.IsNullOrWhiteSpace(value) ? fallback : value!;
+        }
+
+        /// <summary>
+        /// Drops SemVer build metadata: the SDK appends "+&lt;commit sha&gt;" to
+        /// InformationalVersion, which is noise in a title bar and breaks the
+        /// substring checks the update flow makes against release tags.
+        /// </summary>
+        private static string StripBuildMetadata(string version)
+        {
+            int plus = version.IndexOf('+');
+            return plus < 0 ? version : version.Substring(0, plus);
+        }
+    }
+}

--- a/src/EveLens.Common/Services/BuildInfo.cs
+++ b/src/EveLens.Common/Services/BuildInfo.cs
@@ -36,7 +36,7 @@ namespace EveLens.Common.Services
         {
             get
             {
-                string version = AppServices.FileVersionInfo?.ProductVersion ?? "1.0.0";
+                string version = AppServices.AppVersion.ProductVersion ?? "1.0.0";
                 return $"EveLens {version} | evelens.dev | \u00a9 2026 Alia Collins | GPL v2";
             }
         }

--- a/src/EveLens.Common/Services/EveLensClientDataStore.cs
+++ b/src/EveLens.Common/Services/EveLensClientDataStore.cs
@@ -47,7 +47,7 @@ namespace EveLens.Common.Services
 
         public string DataDirectory => EveLensClient.EveLensDataDir;
 
-        public string FileVersion => EveLensClient.FileVersionInfo?.FileVersion ?? "0.0.0.0";
+        public string FileVersion => AppServices.AppVersion.FileVersion ?? "0.0.0.0";
 
         public bool IsClosed => AppServices.Closed;
     }

--- a/src/EveLens.Common/Services/VelopackUpdateService.cs
+++ b/src/EveLens.Common/Services/VelopackUpdateService.cs
@@ -38,7 +38,7 @@ namespace EveLens.Common.Services
         /// otherwise the informational version (which carries the -beta/-alpha
         /// channel; the numeric file version does not and misclassifies builds).</summary>
         public string? CurrentVersion => _manager.CurrentVersion?.ToString()
-            ?? AppServices.FileVersionInfo.ProductVersion;
+            ?? AppServices.AppVersion.ProductVersion;
 
         /// <summary>
         /// The hand-packaged platforms: the macOS .app and Linux archives are not

--- a/src/EveLens.Common/UpdateManager.cs
+++ b/src/EveLens.Common/UpdateManager.cs
@@ -269,7 +269,7 @@ namespace EveLens.Common
         /// <param name="result">The result.</param>
         private static void ScanUpdateFeed(SerializablePatch result)
         {
-            string? fileVersion = AppServices.FileVersionInfo.FileVersion;
+            string? fileVersion = AppServices.AppVersion.FileVersion;
             if (fileVersion == null)
                 return;
 

--- a/src/EveLens.Common/ViewModels/SkinrHubViewModel.cs
+++ b/src/EveLens.Common/ViewModels/SkinrHubViewModel.cs
@@ -116,21 +116,15 @@ namespace EveLens.Common.ViewModels
 
         /// <summary>The selected design's hull, or null before a recipe is loaded.</summary>
         /// <summary>
-        /// True when the staged hull fits the hangar bay the Hangar environment
-        /// renders. The bay is a normal station interior (Jita 4-4's), and just like
-        /// in the game, supercapitals don't dock in those — a titan clips through
-        /// the architecture (user-reported). Gates the Hangar preset until a
-        /// Keepstar-scale bay ships. GroupName is the datafile's English group,
-        /// stable across UI languages.
+        /// True when the staged hull fits the hangar bay. Supercapitals never do:
+        /// a titan clips straight through the station interior's architecture
+        /// (user-reported), and no station bay is authored at Keepstar scale, so
+        /// Titan and Supercarrier hulls get no Hangar environment at all. Every
+        /// other hull keeps it. GroupName is the datafile's English group, stable
+        /// across UI languages.
         /// </summary>
-        public bool HullFitsHangar
-        {
-            get
-            {
-                string group = Hull?.GroupName ?? string.Empty;
-                return group is not ("Titan" or "Supercarrier");
-            }
-        }
+        public bool HullFitsHangar =>
+            Hull?.GroupName is not ("Titan" or "Supercarrier");
 
         public Item? Hull
         {

--- a/src/EveLens.Core/Interfaces/IAppVersionInfo.cs
+++ b/src/EveLens.Core/Interfaces/IAppVersionInfo.cs
@@ -1,0 +1,45 @@
+using System;
+
+namespace EveLens.Core.Interfaces
+{
+    /// <summary>
+    /// The application's own identity and version, read from compiled-in assembly
+    /// metadata rather than from a file on disk.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This exists because <see cref="System.Diagnostics.FileVersionInfo"/> needs a
+    /// path, and a single-file published app has none: <c>Assembly.Location</c> is an
+    /// empty string, so <c>FileVersionInfo.GetVersionInfo(...)</c> throws before the
+    /// first window can open. macOS ships single-file (Apple's bundle rules want only
+    /// Mach-O binaries in <c>Contents/MacOS</c>), so anything on the startup path that
+    /// asks the filesystem "what version am I?" is a crash waiting for a platform.
+    /// Assembly attributes travel inside the binary and answer on every platform.
+    /// </para>
+    /// <para>
+    /// Production: <c>AssemblyAppVersionInfo</c> over the entry assembly's attributes.
+    /// Testing: substitute, or construct <c>AssemblyAppVersionInfo</c> over any assembly.
+    /// </para>
+    /// </remarks>
+    public interface IAppVersionInfo
+    {
+        /// <summary>Product name, e.g. "EveLens". Never null or empty.</summary>
+        string ProductName { get; }
+
+        /// <summary>
+        /// Display version including any pre-release suffix, e.g. "1.5.0-beta.13".
+        /// From AssemblyInformationalVersion, with build metadata (+sha) stripped.
+        /// Never null or empty.
+        /// </summary>
+        string ProductVersion { get; }
+
+        /// <summary>Four-part numeric file version, e.g. "1.5.0.13". Never null or empty.</summary>
+        string FileVersion { get; }
+
+        /// <summary>Company/maintainer string. Never null or empty.</summary>
+        string Company { get; }
+
+        /// <summary>Copyright notice. May be empty if unset.</summary>
+        string Copyright { get; }
+    }
+}

--- a/tests/EveLens.Tests/Regression/SingleFilePublishTests.cs
+++ b/tests/EveLens.Tests/Regression/SingleFilePublishTests.cs
@@ -1,0 +1,93 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using EveLens.Common.Services;
+using EveLens.Core.Interfaces;
+using FluentAssertions;
+using Xunit;
+
+namespace EveLens.Tests.Regression
+{
+    /// <summary>
+    /// Regression tests for the macOS 1.5.0-beta.13 launch failure.
+    ///
+    /// beta.13 was our first single-file publish (Apple's bundle rules want only Mach-O
+    /// binaries in Contents/MacOS, and rcodesign silently skips loose .NET dlls from the
+    /// resource seal, so notarization needs a single file). In a single-file app
+    /// <c>Assembly.Location</c> is an EMPTY STRING. The app version came from
+    /// <c>FileVersionInfo.GetVersionInfo(Assembly.GetEntryAssembly()!.Location)</c>,
+    /// which throws on an empty path — and the version is read on the startup path
+    /// (User-Agent, window title, What's New check), so the app died before its first
+    /// window. Windows and Linux were unaffected because they are not published
+    /// single-file, which is exactly why nothing caught it before release.
+    /// </summary>
+    public class SingleFilePublishTests
+    {
+        [Fact]
+        public void AppVersion_ReportsVersion_WithoutTouchingTheFilesystem()
+        {
+            IAppVersionInfo version = new AssemblyAppVersionInfo();
+
+            version.ProductName.Should().NotBeNullOrWhiteSpace();
+            version.ProductVersion.Should().NotBeNullOrWhiteSpace();
+            version.FileVersion.Should().NotBeNullOrWhiteSpace();
+            version.Company.Should().NotBeNullOrWhiteSpace();
+        }
+
+        [Fact]
+        public void AppVersion_SurvivesAnAssemblyWithNoLocation()
+        {
+            // The single-file condition, reproduced: an assembly whose Location is
+            // empty. Attribute reads must still answer; anything path-based throws.
+            Assembly inMemory = Assembly.Load(
+                File.ReadAllBytes(typeof(AssemblyAppVersionInfo).Assembly.Location));
+            inMemory.Location.Should().BeEmpty("this is what a single-file app reports");
+
+            IAppVersionInfo version = new AssemblyAppVersionInfo(inMemory);
+
+            version.ProductVersion.Should().NotBeNullOrWhiteSpace();
+            version.FileVersion.Should().NotBeNullOrWhiteSpace();
+        }
+
+        [Fact]
+        public void AppVersion_StripsBuildMetadataFromInformationalVersion()
+        {
+            // The SDK appends "+<commit sha>" to AssemblyInformationalVersion. It is
+            // noise in a title bar and it breaks the substring comparisons the update
+            // flow makes against release tags.
+            new AssemblyAppVersionInfo().ProductVersion.Should().NotContain("+");
+        }
+
+        [Fact]
+        public void VersionSources_DoNotAskTheFilesystemForTheirOwnVersion()
+        {
+            // Architecture guard: the whole class of bug, not just the one call site.
+            // Any FileVersionInfo.GetVersionInfo over an assembly Location is a crash
+            // waiting for the next single-file platform.
+            string src = FindSourceRoot();
+            var offenders = Directory
+                .EnumerateFiles(src, "*.cs", SearchOption.AllDirectories)
+                .SelectMany(path => File.ReadLines(path)
+                    .Select((line, i) => (path, line: line.Trim(), number: i + 1)))
+                .Where(l => l.line.Contains("FileVersionInfo.GetVersionInfo") &&
+                            !l.line.StartsWith("//") && !l.line.StartsWith("*"))
+                .Select(l => $"{Path.GetRelativePath(src, l.path)}:{l.number}")
+                .ToList();
+
+            offenders.Should().BeEmpty(
+                "app version must come from assembly attributes (IAppVersionInfo), " +
+                "which a single-file publish still carries");
+        }
+
+        private static string FindSourceRoot()
+        {
+            DirectoryInfo? dir = new(AppContext.BaseDirectory);
+            while (dir != null && !Directory.Exists(Path.Combine(dir.FullName, "src")))
+                dir = dir.Parent;
+
+            dir.Should().NotBeNull("test must run inside the repository");
+            return Path.Combine(dir!.FullName, "src");
+        }
+    }
+}

--- a/updates/evelens-patch-beta.xml
+++ b/updates/evelens-patch-beta.xml
@@ -7,6 +7,16 @@
   <releases>
     <release>
       <date>2026-08-28</date>
+      <version>1.5.0.14</version>
+      <url>https://github.com/aliacollins/evelens/releases/tag/beta</url>
+      <autopatchurl>https://github.com/aliacollins/evelens/releases/download/beta/EveLens-install-1.5.0.exe</autopatchurl>
+      <autopatchargs>/SILENT</autopatchargs>
+      <message><![CDATA[EveLens 1.5.0-beta.14
+
+Mac single-file startup fix; supercapitals lose the Hangar preset]]></message>
+    </release>
+    <release>
+      <date>2026-08-28</date>
       <version>1.5.0.13</version>
       <url>https://github.com/aliacollins/evelens/releases/tag/beta</url>
       <autopatchurl>https://github.com/aliacollins/evelens/releases/download/beta/EveLens-install-1.5.0.exe</autopatchurl>
@@ -94,16 +104,6 @@ Beta 6: SKINR card art decodes once -- fixes the Mac marketplace hang]]></messag
       <message><![CDATA[EveLens 1.5.0-beta.5
 
 Beta 5: Mac SKINR usable without the renderer; macOS/Linux update checks]]></message>
-    </release>
-    <release>
-      <date>2026-08-26</date>
-      <version>1.5.0.4</version>
-      <url>https://github.com/aliacollins/evelens/releases/tag/beta</url>
-      <autopatchurl>https://github.com/aliacollins/evelens/releases/download/beta/EveLens-install-1.5.0.exe</autopatchurl>
-      <autopatchargs>/SILENT</autopatchargs>
-      <message><![CDATA[EveLens 1.5.0-beta.4
-
-Beta 4: Mac SKINR shows honest renderer-coming state on every path]]></message>
     </release>
   </releases>
   <datafiles>


### PR DESCRIPTION
Automated promotion: experimental/skinr -> beta (1.5.0-beta.14)

Mac single-file startup fix; supercapitals lose the Hangar preset