### PR TITLE
Beta 1.5.0-beta.15: macOS signing entitlements fix; Velopack update-path verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to EveLens will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.0-beta.15] - 2026-08-28
+
+### Fixed
+
+- **macOS: the app really opens now** -- beta.14's launch fix was correct but never got to run: the signed app died even earlier, inside the .NET runtime bootstrap ("Failed to create CoreCLR"). Notarization requires Apple's hardened runtime, and the hardened runtime forbids the JIT memory .NET needs unless the app is signed with the allow-jit entitlement -- which our Windows-side signing tool silently dropped when signing the bundle. The signing now attaches the entitlements and refuses to produce a build without them. (beta.14's macOS download was replaced in place with a corrected build the same day.)
+
 ## [1.5.0-beta.14] - 2026-08-28
 
 ### Changed

--- a/SharedAssemblyInfo.cs
+++ b/SharedAssemblyInfo.cs
@@ -30,9 +30,9 @@ using System.Runtime.InteropServices;
 //      Build Number
 //      Revision (0 for stable, 1+ for beta)
 //
-[assembly: AssemblyVersion("1.5.0.14")]
-[assembly: AssemblyFileVersion("1.5.0.14")]
-[assembly: AssemblyInformationalVersion("1.5.0-beta.14")]
+[assembly: AssemblyVersion("1.5.0.15")]
+[assembly: AssemblyFileVersion("1.5.0.15")]
+[assembly: AssemblyInformationalVersion("1.5.0-beta.15")]
 
 // Neutral Language
 [assembly: NeutralResourcesLanguage("en-US")]

--- a/updates/evelens-patch-beta.xml
+++ b/updates/evelens-patch-beta.xml
@@ -7,6 +7,16 @@
   <releases>
     <release>
       <date>2026-08-28</date>
+      <version>1.5.0.15</version>
+      <url>https://github.com/aliacollins/evelens/releases/tag/beta</url>
+      <autopatchurl>https://github.com/aliacollins/evelens/releases/download/beta/EveLens-install-1.5.0.exe</autopatchurl>
+      <autopatchargs>/SILENT</autopatchargs>
+      <message><![CDATA[EveLens 1.5.0-beta.15
+
+macOS signing entitlements fix; Velopack update-path verification]]></message>
+    </release>
+    <release>
+      <date>2026-08-28</date>
       <version>1.5.0.14</version>
       <url>https://github.com/aliacollins/evelens/releases/tag/beta</url>
       <autopatchurl>https://github.com/aliacollins/evelens/releases/download/beta/EveLens-install-1.5.0.exe</autopatchurl>
@@ -94,16 +104,6 @@ Beta 7: status strip speaks one human sentence, never file paths]]></message>
       <message><![CDATA[EveLens 1.5.0-beta.6
 
 Beta 6: SKINR card art decodes once -- fixes the Mac marketplace hang]]></message>
-    </release>
-    <release>
-      <date>2026-08-26</date>
-      <version>1.5.0.5</version>
-      <url>https://github.com/aliacollins/evelens/releases/tag/beta</url>
-      <autopatchurl>https://github.com/aliacollins/evelens/releases/download/beta/EveLens-install-1.5.0.exe</autopatchurl>
-      <autopatchargs>/SILENT</autopatchargs>
-      <message><![CDATA[EveLens 1.5.0-beta.5
-
-Beta 5: Mac SKINR usable without the renderer; macOS/Linux update checks]]></message>
     </release>
   </releases>
   <datafiles>


### PR DESCRIPTION
Automated promotion: experimental/skinr -> beta (1.5.0-beta.15)

macOS signing entitlements fix; Velopack update-path verification