### PR TITLE
Beta 1.5.0-beta.16: macOS in-place auto-updates via Velopack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to EveLens will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.0-beta.16] - 2026-08-28
+
+### Added
+
+- **macOS: in-place auto-updates** -- the Mac app now updates itself the way the Windows app does: it checks in the background, and "Check for Updates" offers Download & Restart instead of a link to the download page. The update swaps the .app bundle in place (wherever you keep it -- Applications or Downloads both work) and relaunches. This build is the last one Mac users need to download by hand; from the next release onward the updater takes over.
+
 ## [1.5.0-beta.15] - 2026-08-28
 
 ### Fixed

--- a/SharedAssemblyInfo.cs
+++ b/SharedAssemblyInfo.cs
@@ -30,9 +30,9 @@ using System.Runtime.InteropServices;
 //      Build Number
 //      Revision (0 for stable, 1+ for beta)
 //
-[assembly: AssemblyVersion("1.5.0.15")]
-[assembly: AssemblyFileVersion("1.5.0.15")]
-[assembly: AssemblyInformationalVersion("1.5.0-beta.15")]
+[assembly: AssemblyVersion("1.5.0.16")]
+[assembly: AssemblyFileVersion("1.5.0.16")]
+[assembly: AssemblyInformationalVersion("1.5.0-beta.16")]
 
 // Neutral Language
 [assembly: NeutralResourcesLanguage("en-US")]

--- a/scripts/release.ps1
+++ b/scripts/release.ps1
@@ -237,7 +237,14 @@ try {
     $ErrorActionPreference = 'Stop'
 
     $appBundle = "publish/macapp/EveLens.app"
+    $macChannel = "$Channel-osx"
     if (Test-Path $appBundle) {
+        # Velopack-enable the bundle BEFORE signing so the signature covers
+        # UpdateMac and the sq.version manifest — with these inside, the mac
+        # app self-updates in place exactly like the Windows install.
+        py -3.12 (Join-Path $PSScriptRoot 'release/velopack-macos.py') inject `
+            $appBundle $Version $macChannel
+        if ($LASTEXITCODE -ne 0) { throw "velopack-macos inject failed." }
         if ($UnsignedMac) {
             Write-Warning "Shipping UNSIGNED mac build (-UnsignedMac)."
         } else {
@@ -251,6 +258,12 @@ try {
         }
         py -3.12 (Join-Path $PSScriptRoot 'release/zip-macapp.py') $appBundle $appBundleZip 'EveLens.app'
         if ($LASTEXITCODE -ne 0) { throw "zip-macapp failed." }
+        # The Velopack feed: full nupkg (carrying the SIGNED app) + the
+        # releases.{channel}-osx.json the in-app GithubSource reads. Both must
+        # ride the same GitHub release as each other.
+        py -3.12 (Join-Path $PSScriptRoot 'release/velopack-macos.py') pack `
+            $appBundle $Version $macChannel 'releases'
+        if ($LASTEXITCODE -ne 0) { throw "velopack-macos pack failed." }
         Write-Host "  macOS .app bundle created." -ForegroundColor Green
     } else {
         Write-Warning "macOS .app bundle creation failed -- raw zip will be uploaded instead."
@@ -301,6 +314,18 @@ if (Test-Path $appBundleZip) {
     $sizeMB = [math]::Round($file.Length / 1MB, 1)
     Write-Host "  $($file.Name) ($sizeMB MB)" -ForegroundColor Green
     $allFiles += $file.FullName
+}
+
+# macOS Velopack feed (in-place auto-update): full nupkg + channel feed json
+foreach ($macVeloFile in @(
+        "releases/EveLens-${Version}-${Channel}-osx-full.nupkg",
+        "releases/releases.${Channel}-osx.json")) {
+    if (Test-Path $macVeloFile) {
+        $file = Get-Item $macVeloFile
+        $sizeMB = [math]::Round($file.Length / 1MB, 1)
+        Write-Host "  $($file.Name) ($sizeMB MB)" -ForegroundColor Green
+        $allFiles += $file.FullName
+    }
 }
 
 # ── Upload ──

--- a/updates/evelens-patch-beta.xml
+++ b/updates/evelens-patch-beta.xml
@@ -7,6 +7,16 @@
   <releases>
     <release>
       <date>2026-08-28</date>
+      <version>1.5.0.16</version>
+      <url>https://github.com/aliacollins/evelens/releases/tag/beta</url>
+      <autopatchurl>https://github.com/aliacollins/evelens/releases/download/beta/EveLens-install-1.5.0.exe</autopatchurl>
+      <autopatchargs>/SILENT</autopatchargs>
+      <message><![CDATA[EveLens 1.5.0-beta.16
+
+macOS in-place auto-updates via Velopack]]></message>
+    </release>
+    <release>
+      <date>2026-08-28</date>
       <version>1.5.0.15</version>
       <url>https://github.com/aliacollins/evelens/releases/tag/beta</url>
       <autopatchurl>https://github.com/aliacollins/evelens/releases/download/beta/EveLens-install-1.5.0.exe</autopatchurl>
@@ -94,16 +104,6 @@ Beta 8: overview sort/reorder controls appear when the second character arrives]
       <message><![CDATA[EveLens 1.5.0-beta.7
 
 Beta 7: status strip speaks one human sentence, never file paths]]></message>
-    </release>
-    <release>
-      <date>2026-08-26</date>
-      <version>1.5.0.6</version>
-      <url>https://github.com/aliacollins/evelens/releases/tag/beta</url>
-      <autopatchurl>https://github.com/aliacollins/evelens/releases/download/beta/EveLens-install-1.5.0.exe</autopatchurl>
-      <autopatchargs>/SILENT</autopatchargs>
-      <message><![CDATA[EveLens 1.5.0-beta.6
-
-Beta 6: SKINR card art decodes once -- fixes the Mac marketplace hang]]></message>
     </release>
   </releases>
   <datafiles>


### PR DESCRIPTION
Automated promotion: experimental/skinr -> beta (1.5.0-beta.16)

macOS in-place auto-updates via Velopack