### PR TITLE
Beta 1.5.0-beta.18: Update diagnostics: Velopack log into trace (PII-redacted), failure dialog with real reason

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to EveLens will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- An update that fails to install now says so, and why, instead of quietly leaving you on the old version. Previously a failed download or a refused install just reset the Download & Restart button, so an update that never happened looked exactly like one that did -- the report you would have had to send us contained no more information than "the version didn't change". Velopack's own account of the update now goes into the EveLens trace log alongside everything else, which matters most on macOS, where the app replaces itself in place and the only visible evidence was the version number. Because these updater messages contain file paths, the OS account name is scrubbed from them before they reach the trace log or the error dialog -- nothing personal ends up in what you share with us.
+
 ## [1.5.0] - 2026-08-28
 
 **The SKINR update -- the biggest release in EveLens history**, packed with new features, engineering overhauls, and community-driven fixes. The headline: EveLens now renders your actual SKIN designs on your actual ships, in real 3D, using **CCP's own Carbon Engine and Trinity graphics engine** -- the same renderer EVE Online itself uses, which CCP open-sourced under MIT. A game engine, running inside a character tool. Around it, the four biggest changes EveLens has ever shipped at once:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,29 +7,61 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.5.0] - 2026-08-28
 
-The biggest EveLens release yet: the SKINR Studio brings real 3D ship rendering into a character tool, the Doctrine Designer grows into a full fleet-readiness workbench, macOS becomes a first-class platform with signing and self-updates, and the whole app now runs on .NET 10. Everything below shipped and hardened across seventeen betas.
+**The SKINR update.** EveLens now renders your actual SKIN designs on your actual ships, in real 3D, using **CCP's own Carbon Trinity engine** -- the same renderer EVE Online itself uses, which CCP open-sourced under MIT. A game engine, running inside a character tool. Around it, the four biggest changes EveLens has ever shipped at once:
 
-### Added
+- **Carbon & Trinity, now in EveLens** -- CCP's open-sourced game engine renders everything in the new SKINR Studio: your designs in 3D, Photo Op fleet portraits, and the entire Paragon Hub marketplace as real renders
+- **macOS, first class** -- code-signed, notarized, and self-updating in place; no more Gatekeeper warnings, no more manual downloads
+- **.NET 10 and Avalonia 12** -- the whole app moved to the newest runtime and UI framework, on all three platforms
+- **Doctrine Designer, round two** -- a full fleet-readiness workbench, built with the community issue by issue
 
-- **The SKINR Studio** -- see your actual SKIN designs on your actual ships, rendered in real 3D by EVE's own engine: the same hull, camera and lighting for every design. Five environments (CCP's studio, a real station hangar, cycling nebulas, sunlight, beauty), Photo Op fleet assembly, and a first-run walkthrough. The 3D engine is a separate one-time download; without it, everything still works through community preview images.
-- **The Paragon Hub, browsable** -- every design on EVE's SKIN marketplace as a real render, judged side by side. Design identities (ship, class, faction, creator, tier) arrive pre-resolved in one request, and ready-made preview images load like a website instead of waiting on a local renderer. Both covered by one opt-in consent.
-- **Doctrine Designer, round two** -- import doctrines from files, clipboard pings, or existing plans; add whole Overview groups at once; see who still needs what with "Show only missing"; every character badge shows the skill points they're short (your injector math, done). The comparison table grew frozen panes, and each character's summary card now IS its column header, so names, cards and checkmarks stay in one aligned system.
+Everything below shipped and hardened across seventeen betas.
+
+### The SKINR Studio
+
+- **Your designs, in real 3D** -- rendered by Trinity, the engine New Eden runs on, so every nanocoating, every reflection, every running light is exactly what the game shows. The same hull, camera and lighting for every design: you judge the SKIN, not the screenshot. Five environments: CCP's own studio, a real station hangar, cycling nebulas, hard sunlight, and a beauty pass. (Supercapitals skip the hangar -- a titan doesn't fit in a station bay, in the game or here.)
+- **The Paragon Hub, browsable** -- every design on EVE's SKIN marketplace as a real render, side by side. Ship, class, faction, creator and tier arrive instantly, and ready-made preview images fill the grid in seconds. One opt-in consent covers both.
+- **Photo Op** -- assemble your own ships into a fleet formation around your primary and frame the shot: your Rifter escorted by your own battleships, every hull wearing its own SKIN. The screenshot you always wanted the game to take.
+- **A one-time engine download** -- the 3D renderer is a separate add-on you install once; without it, everything still works through community preview images.
+- **A first-run walkthrough** -- the studio introduces itself: what it is, the one ESI permission it needs, and the optional renderer.
+
+### macOS
+
+- **Signed and notarized** -- Gatekeeper opens EveLens with a double-click.
+- **Self-updating** -- Check for Updates offers Download & Restart; the .app swaps in place wherever you keep it and relaunches on the new version. Linux gets background update checks too.
+
+### Doctrine Designer
+
+- **Import from anywhere** -- alliance .emp/.xml files, clipboard doctrine pings ("Skill Name V", roman or numeric), or any character's existing plan.
+- **Whole groups at once** -- one click subscribes every member of an Overview group.
+- **"Show only missing"** -- collapses the comparison to who still needs what, without the sea of green checkmarks.
+- **A way out** -- every character card has a remove button now; doctrines used to be a one-way door.
+- **Missing SP on every badge** -- the injector math, done: each character shows the skill points they're short of the whole doctrine.
+- **An aligned comparison** -- each character's summary card IS its column header now; cards, names and checkmarks scroll as one system, with frozen panes both ways.
+
+### The Plan Editor, rebuilt
+
+- **A schedule, not a spreadsheet** -- plans group into attribute segments with real header rows, gold "REMAP BEFORE" dividers mark exactly where each scheduled remap lands, and the header leads with total training time and a live optimization badge that re-judges itself whenever you reorder skills.
+- **Direct manipulation** -- click a level pip to retarget a skill, drag to reorder, select a skill for an inspector with prerequisites, what it unlocks, and a locate-in-plan jump.
+- **The Attribute Optimizer got honest** -- remaps are placed globally against your whole remap budget (including "no remap at all" when one saves nothing), a proposed-schedule timeline explains WHY each remap lands where it does, and an active booster is called out instead of reading as bad values.
 - **Skill priorities, made real** -- every plan row shows its priority, "Group by Priority" turns long plans into milestone bands, and prerequisites always stay ahead of the skills that need them.
-- **Overview, reworked** -- drag characters onto each other to form groups, sort and density controls, group totals at a glance, saved character comparisons, and cards that scale with your font size.
-- **macOS, first class** -- the app is code-signed and notarized (no more Gatekeeper warnings), and it updates itself in place: Check for Updates offers Download & Restart, the .app swaps wherever you keep it, and it relaunches on the new version. Linux gets background update checks too.
 
-### Changed
+### Also in this release
 
-- **EveLens now runs on .NET 10** with the latest Avalonia UI.
+- **Overview, reworked** -- drag characters onto each other to form groups, sort and density controls, group totals at a glance, saved character comparisons, cards that scale with your font size.
+- **Skill search looks inside descriptions** -- find skills by what they do, not just what they're called.
 - **EVE static data build 3480926** (August 2026) -- all game data regenerated from CCP's Static Data Export.
 
 ### Fixed
 
 - The Paragon Hub no longer freezes the app while it identifies designs; grids are virtualized and thumbnails slot in one card at a time.
 - Supercapitals no longer clip through the Hangar environment -- titans and supercarriers simply don't offer it, like the game itself.
-- Doctrine comparison ticks stay under their character to the last column; the frozen panes scroll in sync whichever pane the mouse wheel lands on; scrollbars are visible at rest app-wide.
-- Skill Planner keeps your hand-made order, roman-numeral skill lists import ("Amarr Titan V"), and Change Priority actually responds.
-- Dozens of community-reported fixes across the betas -- thank you odon, Fastburn, AnszaKalltiern, Agge65 and everyone on the tracker.
+- Doctrine comparison ticks stay under their character to the last column, and scrollbars are visible at rest app-wide.
+- Skill Planner keeps your hand-made order, roman-numeral skill lists import, and Change Priority actually responds.
+- Dozens more community-reported fixes across the betas.
+
+### Thank you
+
+1.5.0 was shaped issue by issue with the people who use it: @odon (the Doctrine Designer's round two and the SKINR feedback that drove a dozen fixes), @Mordano (skill priorities and plan ordering), @jackmurray (who pushed for the .NET 10 move), @shawndibble (the Attribute Optimizer's remap-placement bug), @Dureiken (booster-aware optimization), @Kickunio and @Agge65 (the Overview's grouping and badge fixes), and everyone who filed, tested, and re-tested across seventeen betas. o7
 
 ## [1.5.0-beta.17] - 2026-08-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,32 @@ All notable changes to EveLens will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.0] - 2026-08-28
+
+The biggest EveLens release yet: the SKINR Studio brings real 3D ship rendering into a character tool, the Doctrine Designer grows into a full fleet-readiness workbench, macOS becomes a first-class platform with signing and self-updates, and the whole app now runs on .NET 10. Everything below shipped and hardened across seventeen betas.
+
+### Added
+
+- **The SKINR Studio** -- see your actual SKIN designs on your actual ships, rendered in real 3D by EVE's own engine: the same hull, camera and lighting for every design. Five environments (CCP's studio, a real station hangar, cycling nebulas, sunlight, beauty), Photo Op fleet assembly, and a first-run walkthrough. The 3D engine is a separate one-time download; without it, everything still works through community preview images.
+- **The Paragon Hub, browsable** -- every design on EVE's SKIN marketplace as a real render, judged side by side. Design identities (ship, class, faction, creator, tier) arrive pre-resolved in one request, and ready-made preview images load like a website instead of waiting on a local renderer. Both covered by one opt-in consent.
+- **Doctrine Designer, round two** -- import doctrines from files, clipboard pings, or existing plans; add whole Overview groups at once; see who still needs what with "Show only missing"; every character badge shows the skill points they're short (your injector math, done). The comparison table grew frozen panes, and each character's summary card now IS its column header, so names, cards and checkmarks stay in one aligned system.
+- **Skill priorities, made real** -- every plan row shows its priority, "Group by Priority" turns long plans into milestone bands, and prerequisites always stay ahead of the skills that need them.
+- **Overview, reworked** -- drag characters onto each other to form groups, sort and density controls, group totals at a glance, saved character comparisons, and cards that scale with your font size.
+- **macOS, first class** -- the app is code-signed and notarized (no more Gatekeeper warnings), and it updates itself in place: Check for Updates offers Download & Restart, the .app swaps wherever you keep it, and it relaunches on the new version. Linux gets background update checks too.
+
+### Changed
+
+- **EveLens now runs on .NET 10** with the latest Avalonia UI.
+- **EVE static data build 3480926** (August 2026) -- all game data regenerated from CCP's Static Data Export.
+
+### Fixed
+
+- The Paragon Hub no longer freezes the app while it identifies designs; grids are virtualized and thumbnails slot in one card at a time.
+- Supercapitals no longer clip through the Hangar environment -- titans and supercarriers simply don't offer it, like the game itself.
+- Doctrine comparison ticks stay under their character to the last column; the frozen panes scroll in sync whichever pane the mouse wheel lands on; scrollbars are visible at rest app-wide.
+- Skill Planner keeps your hand-made order, roman-numeral skill lists import ("Amarr Titan V"), and Change Priority actually responds.
+- Dozens of community-reported fixes across the betas -- thank you odon, Fastburn, AnszaKalltiern, Agge65 and everyone on the tracker.
+
 ## [1.5.0-beta.17] - 2026-08-28
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.5.0] - 2026-08-28
 
-**The SKINR update.** EveLens now renders your actual SKIN designs on your actual ships, in real 3D, using **CCP's own Carbon Trinity engine** -- the same renderer EVE Online itself uses, which CCP open-sourced under MIT. A game engine, running inside a character tool. Around it, the four biggest changes EveLens has ever shipped at once:
+**The SKINR update -- the biggest release in EveLens history**, packed with new features, engineering overhauls, and community-driven fixes. The headline: EveLens now renders your actual SKIN designs on your actual ships, in real 3D, using **CCP's own Carbon Engine and Trinity graphics engine** -- the same renderer EVE Online itself uses, which CCP open-sourced under MIT. A game engine, running inside a character tool. Around it, the four biggest changes EveLens has ever shipped at once:
 
 - **Carbon & Trinity, now in EveLens** -- CCP's open-sourced game engine renders everything in the new SKINR Studio: your designs in 3D, Photo Op fleet portraits, and the entire Paragon Hub marketplace as real renders
 - **macOS, first class** -- code-signed, notarized, and self-updating in place; no more Gatekeeper warnings, no more manual downloads

--- a/README.md
+++ b/README.md
@@ -149,8 +149,8 @@ A clock icon in the status bar shows how many of your characters need training a
 
 | Channel | Use Case | Download |
 |---------|----------|----------|
-| **Stable** | Recommended for daily use | [Latest Release](https://github.com/aliacollins/evelens/releases/latest) |
-| Beta | Early access to what ships next | [Beta Releases](https://github.com/aliacollins/evelens/releases) |
+| Stable | Recommended for daily use | [Latest Release](https://github.com/aliacollins/evelens/releases/latest) |
+| **Beta** | Early access to what ships next(you are here) | [Beta Releases](https://github.com/aliacollins/evelens/releases) |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -196,7 +196,19 @@ I'm not accepting donations -- I just want to know if EveLens makes your EVE lif
 
 ---
 
-## What's New in 1.4.0
+## What's New in 1.5.0
+
+- **The SKINR Studio** -- your SKIN designs on your ships, rendered in real 3D by EVE's own engine; five environments, Photo Op fleet shots, one-time 3D engine download (community preview images without it)
+- **Paragon Hub browser** -- every marketplace design as a real render, side by side, with instant pre-resolved identities and preview images
+- **Doctrine Designer round two** -- import from files/clipboard/plans, add whole groups, "Show only missing", missing-SP badges, aligned card columns with frozen panes
+- **Skill priorities** -- visible on every plan row, "Group by Priority" milestone bands
+- **Overview rework** -- drag-to-group, sort and density controls, group totals, saved comparisons
+- **macOS first class** -- signed, notarized, and self-updating in place; Linux gets update checks too
+- **.NET 10** and EVE static data build 3480926
+
+Full details: [CHANGELOG.md](CHANGELOG.md)
+
+## What Was New in 1.4.0
 
 - **Doctrine Designer** -- create shared skill templates, assign characters, compare training times, generate personal plans (Ctrl+G)
 - **Chinese language (简体中文)** -- full UI + 50K SDE translations with CCP official game terms
@@ -209,15 +221,6 @@ I'm not accepting donations -- I just want to know if EveLens makes your EVE lif
 - **Website download links** -- no longer 404 between releases
 
 Full details: [CHANGELOG.md](CHANGELOG.md)
-
-## What Was New in 1.2.0
-
-- **Drag-to-reorder in Plan Editor** -- grab, multi-select, drag groups with real-time prerequisite validation
-- **Skill Farm Dashboard** -- full economics for extraction characters: Jita pricing, tax, profit projections, Omega sustainability
-- **Plan import/export overhaul** -- supports .emp, .txt, and EVE game clipboard format
-- **Keyboard shortcuts** -- Ctrl+Q, Ctrl+W, Ctrl+N, Ctrl+M, Ctrl+, and more
-
-Full details: [1.2.0 Release Notes](https://github.com/aliacollins/EveLens/releases/tag/v1.2.0)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@
 
 ---
 
-## EveLens 1.3.0 Beta
+## What is EveLens?
 
-EveLens is a complete, ground-up rewrite of EVEMon -- the character planner EVE pilots relied on for nearly 20 years. What was once a Windows-only desktop app locked to legacy frameworks is now a modern, cross-platform tool built on **.NET 10** and **Avalonia UI**, running natively on **Windows, Linux, and macOS**.
+EveLens is a free, open-source **skill planner and character tracker for EVE Online** -- the modern successor to EVEMon, the tool EVE pilots relied on for nearly twenty years. It plans skill training, optimizes attribute remaps, monitors every character you own (100+ supported), compares fleets against doctrines, and -- as of 1.5.0 -- renders your **SKIN designs on your own ships in real 3D**, powered by **CCP's own Carbon Engine and Trinity graphics engine**, open-sourced by CCP and now running inside EveLens.
 
-This isn't a patch or a fork update. It's 114,000 lines of WinForms reduced to 34,000 lines of modern code, with 1,857 tests, 14 architectural laws, and support for **100+ characters** out of the box.
+It runs natively on **Windows, Linux, and macOS** (signed and notarized), built on **.NET 10** and **Avalonia 12**, backed by 2,400+ automated tests. Your data comes straight from CCP's ESI API with scopes you choose; nothing leaves your machine without an explicit opt-in.
 
 **Website:** [evelens.dev](https://evelens.dev)
 
@@ -66,37 +66,19 @@ No separate .NET runtime install needed -- releases are self-contained.
 
 1. Download `EveLens-*-osx-arm64.app.zip` from the release page
 2. Extract the zip -- you'll get `EveLens.app`
-3. Drag `EveLens.app` to your Applications folder
-4. **First launch -- important:** macOS blocks unsigned apps. Open Terminal and run:
+3. Drag `EveLens.app` to your Applications folder (or run it from anywhere -- it's portable)
+4. Double-click to open. That's it.
 
-```bash
-# Navigate to where you extracted EveLens.app, then run:
-xattr -cr EveLens.app
-```
-
-This removes the macOS quarantine flag. Double-click to open normally after this.
-
-> **Why is this needed?** EveLens is code-signed on Windows but not yet on macOS (Apple requires a separate $99/year developer certificate). Without a macOS signature, Gatekeeper reports the app as "broken" rather than "unsigned", so the usual right-click Open workaround doesn't work. The `xattr -cr` command is the reliable fix. The app is safe -- it's open source and you can verify the code yourself.
-
-### macOS (Portable)
-
-```bash
-unzip EveLens-*-osx-arm64.zip -d evelens
-cd evelens
-
-# Remove quarantine and set executable permission
-xattr -cr .
-chmod +x EveLens
-
-# Run
-./EveLens
-```
+**EveLens is code-signed and notarized by Apple** as of 1.5.0 -- Gatekeeper opens it like any Mac app. No Terminal, no `xattr`, no right-click workarounds. And the app **updates itself in place** from here on: Check for Updates downloads the new version, swaps the .app wherever you keep it, and relaunches.
 
 > **Coming from EVEMon?** We recommend a fresh start. EveLens is a complete rewrite -- your EVE characters are tied to your ESI tokens, not your old settings. Add your characters through the ESI login and you're good to go.
 
 ---
 
 ## What You Get
+
+### The SKINR Studio (NEW in 1.5.0)
+The engine that renders New Eden now renders inside EveLens. **CCP open-sourced their Carbon Engine and Trinity graphics engine under MIT -- EveLens runs them**, so your SKIN designs appear on your actual ships with the exact nanocoatings, reflections and lighting the game shows: not screenshots, not mockups, the real renderer. Judge every design in CCP's studio, a live station hangar, deep space nebulas, hard sunlight, or a beauty pass. Assemble **Photo Op** fleet portraits from your own ships. Browse the entire **Paragon Hub marketplace** as real renders, side by side, same camera and lighting for every design. The 3D engine is a one-time optional download; community preview images cover you without it.
 
 ### Cross-Platform -- Finally
 EveLens runs natively on Windows, Linux, and macOS from a single codebase. System tray, notifications, clipboard, and dialogs all use native platform APIs. Same features, same UI, same updates on every platform. No Wine, no workarounds.
@@ -167,9 +149,8 @@ A clock icon in the status bar shows how many of your characters need training a
 
 | Channel | Use Case | Download |
 |---------|----------|----------|
-| Stable | Recommended for daily use | [Latest Release](https://github.com/aliacollins/evelens/releases/latest) |
-| **Beta** | Pre-release testing(you are here) | [Beta Releases](https://github.com/aliacollins/evelens/releases) |
-| Alpha | Bleeding edge, experimental features | [Alpha Releases](https://github.com/aliacollins/evelens/releases) |
+| **Stable** | Recommended for daily use | [Latest Release](https://github.com/aliacollins/evelens/releases/latest) |
+| Beta | Early access to what ships next | [Beta Releases](https://github.com/aliacollins/evelens/releases) |
 
 ---
 
@@ -224,17 +205,17 @@ Full details: [CHANGELOG.md](CHANGELOG.md)
 
 ---
 
-## Features Being Tested
+## Frequently Asked Questions
 
-- Skill Farm: configurable SP base per character
-- "What's New" dialog on update
-- Code Graph system for AI-assisted development
+**Is EveLens free?** Yes -- free and open source under GPL v2, no donations accepted. The optional 3D render engine is also free.
 
-## Alpha Changelog (Cumulative)
+**Is it safe to log in with?** EveLens uses CCP's official ESI API with OAuth -- it never sees your password, and you choose exactly which data scopes it may read. Everything stays on your machine unless you explicitly opt in to community features.
 
-- Skill Farm Dashboard: per-character configurable SP floor (click Base column)
-- What's New dialog: shown once per version after update, reads from CHANGELOG.md
-- Code Graph: living dependency map with validation and Claude skill integration
+**Does it work on Mac?** Yes, natively on Apple Silicon -- code-signed, notarized, and self-updating as of 1.5.0. Linux (AppImage) and Windows too, from one codebase.
+
+**Can it replace EVEMon?** That's the point. EveLens is a ground-up rewrite of EVEMon for modern .NET -- same lineage, same license, built for today's ESI and 100+ characters. Add your characters through ESI login and you're home.
+
+**How does the 3D SKIN rendering work?** CCP open-sourced their Carbon Engine and Trinity graphics engine under MIT; EveLens runs that engine locally with the game's own art assets from CCP's CDN, so what you see is what the game renders.
 
 ---
 
@@ -242,7 +223,9 @@ Full details: [CHANGELOG.md](CHANGELOG.md)
 
 | Version | Date | Highlights |
 |---------|------|------------|
-| **1.3.0-beta.3** | May 3, 2026 | Doctrine Designer, Chinese language, CSV export, Skill Farm sort, plan editor overhaul, EveLens branded icons, custom browser setting, SDE build 3328718, macOS/Linux icon fixes |
+| **[1.5.0](https://github.com/aliacollins/EveLens/releases/tag/v1.5.0)** | August 28, 2026 | The SKINR Studio (CCP's Carbon/Trinity engine in EveLens), Paragon Hub browser, Photo Op, macOS signed + self-updating, .NET 10 + Avalonia 12, Doctrine Designer round two, Plan Editor rebuild |
+| **[1.4.1](https://github.com/aliacollins/EveLens/releases/tag/v1.4.1)** | August 10, 2026 | Korean language, PI overhaul, community fix train, SDE 3458726 |
+| **[1.3.0](https://github.com/aliacollins/EveLens/releases/tag/v1.3.0)** | May 10, 2026 | Doctrine Designer, Chinese language, CSV export, Skill Farm sort, plan editor overhaul |
 | **[1.2.1](https://github.com/aliacollins/EveLens/releases/tag/v1.2.1)** | April 9, 2026 | Fix plan training time calculation |
 | **[1.2.0](https://github.com/aliacollins/EveLens/releases/tag/v1.2.0)** | April 5, 2026 | Plan Editor drag-reorder, Skill Farm Dashboard, plan import fix, keyboard shortcuts, queue health cards |
 | **[1.1.0](https://github.com/aliacollins/EveLens/releases/tag/v1.1.0)** | March 29, 2026 | Character Skill Comparison, variable font scaling, queue health monitor, ESI token fix, add character UX, group management redesign |

--- a/SharedAssemblyInfo.cs
+++ b/SharedAssemblyInfo.cs
@@ -30,9 +30,9 @@ using System.Runtime.InteropServices;
 //      Build Number
 //      Revision (0 for stable, 1+ for beta)
 //
-[assembly: AssemblyVersion("1.5.0.13")]
-[assembly: AssemblyFileVersion("1.5.0.13")]
-[assembly: AssemblyInformationalVersion("1.5.0-beta.13")]
+[assembly: AssemblyVersion("1.5.0.0")]
+[assembly: AssemblyFileVersion("1.5.0.0")]
+[assembly: AssemblyInformationalVersion("1.5.0")]
 
 // Neutral Language
 [assembly: NeutralResourcesLanguage("en-US")]

--- a/SharedAssemblyInfo.cs
+++ b/SharedAssemblyInfo.cs
@@ -30,9 +30,9 @@ using System.Runtime.InteropServices;
 //      Build Number
 //      Revision (0 for stable, 1+ for beta)
 //
-[assembly: AssemblyVersion("1.5.0.0")]
-[assembly: AssemblyFileVersion("1.5.0.0")]
-[assembly: AssemblyInformationalVersion("1.5.0")]
+[assembly: AssemblyVersion("1.5.0.18")]
+[assembly: AssemblyFileVersion("1.5.0.18")]
+[assembly: AssemblyInformationalVersion("1.5.0-beta.18")]
 
 // Neutral Language
 [assembly: NeutralResourcesLanguage("en-US")]

--- a/src/EveLens.Avalonia/Program.cs
+++ b/src/EveLens.Avalonia/Program.cs
@@ -15,6 +15,7 @@ using Avalonia.Layout;
 using Avalonia.Media;
 using Avalonia.Themes.Fluent;
 using EveLens.Common;
+using EveLens.Common.Services;
 using Velopack;
 using EveLens.Avalonia.Services;
 namespace EveLens.Avalonia
@@ -29,7 +30,10 @@ namespace EveLens.Avalonia
         {
             // Velopack startup hook — handles install/uninstall/update lifecycle events.
             // Must be the FIRST thing in Main() before any other code runs.
-            VelopackApp.Build().Run();
+            // The logger matters on macOS in particular: this hook is what runs in the
+            // freshly swapped-in app, so it is the only place that can testify whether
+            // an in-place update actually took effect.
+            VelopackApp.Build().SetLogger(AppServices.VelopackLogger).Run();
 
             // Install the process-wide exception backstop as early as possible, so any
             // exception on a background thread or unobserved Task is logged instead of

--- a/src/EveLens.Avalonia/Views/MainWindow.axaml.cs
+++ b/src/EveLens.Avalonia/Views/MainWindow.axaml.cs
@@ -2124,17 +2124,25 @@ namespace EveLens.Avalonia.Views
                             downloadBtn.IsEnabled = false;
                             downloadBtn.Content = "Downloading...";
                             bool downloaded = await (AppServices.VelopackUpdate?.DownloadUpdateAsync() ?? Task.FromResult(false));
-                            if (downloaded)
-                                AppServices.VelopackUpdate?.ApplyAndRestart();
-                            else
-                            {
-                                downloadBtn.Content = "Download & Restart";
-                                downloadBtn.IsEnabled = true;
-                            }
+
+                            // On success Velopack replaces the app and exits the
+                            // process, so nothing below this runs. Anything that does
+                            // run is a failure the user deserves to see — silently
+                            // resetting the button is how an update that never
+                            // installed looked identical to one that did.
+                            bool applied = downloaded &&
+                                (AppServices.VelopackUpdate?.ApplyAndRestart() ?? false);
+
+                            if (!downloaded || !applied)
+                                ShowUpdateFailure(updateDialog, downloaded);
+
+                            downloadBtn.Content = "Download & Restart";
+                            downloadBtn.IsEnabled = true;
                         }
                         catch (Exception ex)
                         {
-                            Debug.WriteLine($"Download error: {ex}");
+                            AppServices.TraceService?.Trace($"Update install error: {ex}");
+                            ShowUpdateFailure(updateDialog, downloaded: false);
                             downloadBtn.Content = "Download & Restart";
                             downloadBtn.IsEnabled = true;
                         }
@@ -2226,6 +2234,102 @@ namespace EveLens.Avalonia.Views
             catch (Exception ex)
             {
                 Debug.WriteLine($"Error checking for updates: {ex}");
+            }
+        }
+
+        /// <summary>
+        /// Tells the user an update could not be installed, and why. An update that
+        /// fails must never look like one that succeeded: before this, a failed
+        /// download or a refused install just reset the button, leaving the app on the
+        /// old version with no explanation anywhere the user could reach.
+        /// </summary>
+        private async void ShowUpdateFailure(Window owner, bool downloaded)
+        {
+            try
+            {
+                string reason = AppServices.VelopackUpdate?.LastError
+                    ?? "The update could not be installed.";
+                string stage = downloaded
+                    ? "EveLens downloaded the update but could not install it."
+                    : "EveLens could not download the update.";
+
+                var panel = new StackPanel { Margin = new Thickness(20), Spacing = 10 };
+                panel.Children.Add(new TextBlock
+                {
+                    Text = "Update not installed",
+                    FontSize = FontScaleService.Subheading,
+                    FontWeight = FontWeight.SemiBold,
+                    Foreground = FindStripBrush("EveErrorRedBrush", Brushes.IndianRed),
+                });
+                panel.Children.Add(new TextBlock
+                {
+                    Text = $"{stage} You are still running the previous version.",
+                    FontSize = FontScaleService.Body,
+                    TextWrapping = global::Avalonia.Media.TextWrapping.Wrap,
+                    Foreground = FindStripBrush("EveTextPrimaryBrush", Brushes.White),
+                });
+                panel.Children.Add(new TextBlock
+                {
+                    Text = reason,
+                    FontSize = FontScaleService.Body,
+                    TextWrapping = global::Avalonia.Media.TextWrapping.Wrap,
+                    Foreground = FindStripBrush("EveTextSecondaryBrush", Brushes.Gray),
+                });
+                panel.Children.Add(new TextBlock
+                {
+                    Text = "You can always install the latest version by hand from the "
+                         + "releases page. If this keeps happening, please report it — "
+                         + "the details are in the EveLens trace log.",
+                    FontSize = FontScaleService.Body,
+                    TextWrapping = global::Avalonia.Media.TextWrapping.Wrap,
+                    Foreground = FindStripBrush("EveTextDisabledBrush", Brushes.DimGray),
+                });
+
+                var releasesBtn = new Button
+                {
+                    Content = "Open Releases Page",
+                    FontSize = FontScaleService.Body,
+                    Padding = new Thickness(12, 5),
+                    CornerRadius = new CornerRadius(12),
+                };
+                var closeBtn = new Button
+                {
+                    Content = "Close",
+                    FontSize = FontScaleService.Body,
+                    Padding = new Thickness(12, 5),
+                    CornerRadius = new CornerRadius(12),
+                };
+                panel.Children.Add(new StackPanel
+                {
+                    Orientation = global::Avalonia.Layout.Orientation.Horizontal,
+                    HorizontalAlignment = HorizontalAlignment.Right,
+                    Spacing = 8,
+                    Children = { closeBtn, releasesBtn }
+                });
+
+                var dialog = new Window
+                {
+                    Title = "Update Not Installed",
+                    Width = 480, Height = 300,
+                    WindowStartupLocation = WindowStartupLocation.CenterOwner,
+                    Content = panel,
+                };
+                releasesBtn.Click += (_, _) =>
+                {
+                    try
+                    {
+                        Util.OpenURL(new Uri(
+                            "https://github.com/aliacollins/evelens/releases/latest"));
+                    }
+                    catch { }
+                };
+                closeBtn.Click += (_, _) => dialog.Close();
+
+                await dialog.ShowDialog(owner);
+            }
+            catch (Exception ex)
+            {
+                AppServices.TraceService?.Trace($"ShowUpdateFailure error: {ex}");
             }
         }
 

--- a/src/EveLens.Common/Helpers/DiagnosticReportBuilder.cs
+++ b/src/EveLens.Common/Helpers/DiagnosticReportBuilder.cs
@@ -307,6 +307,10 @@ namespace EveLens.Common.Helpers
             // UNC paths: \\server\ -> \\[REDACTED]\
             text = s_uncPath.Replace(text, @"\\[REDACTED]\");
 
+            // macOS/Linux home paths (/Users/name/, /home/name/) and Windows paths
+            // without a trailing separator — the regex above misses both.
+            text = text.RedactUserName();
+
             // Machine name and Windows username
             try
             {

--- a/src/EveLens.Common/Services/AppServices.cs
+++ b/src/EveLens.Common/Services/AppServices.cs
@@ -42,6 +42,7 @@ namespace EveLens.Common.Services
         private static Lazy<CharacterFactory> s_characterFactory = new(() => new CharacterFactory(
             CharacterRepository, EventAggregator, EveLensClientCharacterServices.Instance));
         private static Lazy<ITraceService> s_traceService = new(() => new TraceService());
+        private static readonly Lazy<VelopackTraceLogger> s_velopackLogger = new(() => new VelopackTraceLogger());
         private static Lazy<IApplicationPaths> s_applicationPaths = new(() => new ApplicationPathsAdapter());
         private static Lazy<INameResolver> s_nameResolver = new(() => new NameResolverAdapter());
         private static Lazy<IStationResolver> s_stationResolver = new(() => new StationResolverAdapter());
@@ -326,6 +327,14 @@ namespace EveLens.Common.Services
         /// Gets the trace service for diagnostic logging.
         /// </summary>
         public static ITraceService TraceService => s_traceService.Value;
+
+        /// <summary>
+        /// Gets the sink that carries Velopack's own account of an update into the
+        /// EveLens trace log. Shared deliberately: the startup hook installs it before
+        /// any service exists, and <see cref="VelopackUpdateService"/> reads the same
+        /// instance to report why an update could not be applied.
+        /// </summary>
+        public static VelopackTraceLogger VelopackLogger => s_velopackLogger.Value;
 
         /// <summary>
         /// Gets the application paths service.

--- a/src/EveLens.Common/Services/VelopackTraceLogger.cs
+++ b/src/EveLens.Common/Services/VelopackTraceLogger.cs
@@ -1,0 +1,91 @@
+// EveLens — Character Intelligence for EVE Online
+// Copyright © 2006-2021 EVEMon Development Team, © 2025-2026 Alia Collins
+// Built with Claude Code (Anthropic)
+// Licensed under GPL v2 — see LICENSE for details
+
+using System;
+using System.Collections.Generic;
+using EveLens.Common.Extensions;
+using Velopack.Logging;
+
+namespace EveLens.Common.Services
+{
+    /// <summary>
+    /// Routes Velopack's internal log output into EveLens's own trace pipeline.
+    /// </summary>
+    /// <remarks>
+    /// Without this, everything Velopack does — locator initialisation, which feed it
+    /// read, the exact <c>Update</c>/<c>UpdateMac</c> command line it spawned, why an
+    /// apply was refused — is written to a logger the app never installs and is lost.
+    /// That made a failed macOS in-place update indistinguishable from one that never
+    /// started: the only symptom was a version that did not change.
+    ///
+    /// Velopack also keeps its own rolling log next to the app (and on macOS the native
+    /// updater writes <c>~/Library/Caches/velopack.log</c>), but those files live outside
+    /// the app's own diagnostics. Forwarding into <see cref="ITraceService"/> puts update
+    /// activity in the trace file and on the TCP diagnostic stream alongside everything
+    /// else, so a user can report an update failure the same way they report any bug.
+    ///
+    /// The last few lines are also retained in memory so the update UI can show the user
+    /// the real reason a download or apply failed instead of silently resetting a button.
+    /// </remarks>
+    public sealed class VelopackTraceLogger : IVelopackLogger
+    {
+        /// <summary>How many recent lines to retain for error reporting in the UI.</summary>
+        private const int RetainedLines = 20;
+
+        private readonly object _sync = new();
+        private readonly Queue<string> _recent = new();
+
+        /// <summary>
+        /// The most recent warning or error Velopack reported, or null if it has not
+        /// complained. Surfaced in the update dialog when an update cannot be applied.
+        /// </summary>
+        public string? LastProblem { get; private set; }
+
+        public void Log(VelopackLogLevel logLevel, string? message, Exception? exception)
+        {
+            if (string.IsNullOrWhiteSpace(message) && exception == null)
+                return;
+
+            // Velopack's Trace/Debug levels are extremely chatty (per-chunk download
+            // progress); they would drown the trace file for no diagnostic gain.
+            if (logLevel < VelopackLogLevel.Information)
+                return;
+
+            string text = exception == null
+                ? message ?? string.Empty
+                : $"{message} — {exception.GetType().Name}: {exception.Message}";
+
+            // Velopack logs absolute paths (packages dir, bundle location), which embed
+            // the OS account name. Scrub once here, at the single point of entry, so the
+            // trace file, the TCP diagnostic stream, the retained tail and the failure
+            // dialog all inherit the redaction.
+            text = text.RedactUserName();
+
+            string line = $"Velopack [{logLevel}] {text}";
+
+            lock (_sync)
+            {
+                _recent.Enqueue(line);
+                while (_recent.Count > RetainedLines)
+                    _recent.Dequeue();
+
+                if (logLevel >= VelopackLogLevel.Warning)
+                    LastProblem = text;
+            }
+
+            AppServices.TraceService?.Trace(line);
+        }
+
+        /// <summary>
+        /// The retained tail of Velopack's log, newest last — the context to include in
+        /// an update failure report.
+        /// </summary>
+        public string RecentLog()
+        {
+            lock (_sync)
+                return string.Join(Environment.NewLine, _recent);
+        }
+    }
+}

--- a/src/EveLens.Common/Services/VelopackUpdateService.cs
+++ b/src/EveLens.Common/Services/VelopackUpdateService.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using EveLens.Common.Extensions;
 using EveLens.Core.Interfaces;
 using Velopack.Sources;
 using VelopackUpdateManager = Velopack.UpdateManager;
@@ -24,6 +25,7 @@ namespace EveLens.Common.Services
         private static readonly TimeSpan InitialDelay = TimeSpan.FromSeconds(15);
 
         private readonly VelopackUpdateManager _manager;
+        private readonly VelopackTraceLogger _velopackLog = AppServices.VelopackLogger;
         private readonly IEventAggregator? _eventAggregator;
         private readonly IDispatcher? _dispatcher;
         private CancellationTokenSource? _cts;
@@ -88,8 +90,27 @@ namespace EveLens.Common.Services
             _dispatcher = dispatcher;
 
             var source = new GithubSource(GitHubRepoUrl, null, prerelease: true);
+
             _manager = new VelopackUpdateManager(source);
+
+            // Velopack routes its logging through the locator the startup hook
+            // installed. Attach there if that hook did not run (tests, dev builds) so
+            // the account of an update is never silently discarded — that missing
+            // account is what made a failed macOS in-place update undiagnosable.
+            if (!Velopack.Locators.VelopackLocator.IsCurrentSet)
+                AppServices.TraceService?.Trace(
+                    "VelopackUpdate: no Velopack locator installed — update logging unavailable");
         }
+
+        /// <summary>
+        /// Why the last download or apply failed, or null if nothing has failed.
+        /// Shown to the user rather than swallowed, so an update that cannot install
+        /// says so instead of leaving the app quietly on the old version.
+        /// </summary>
+        public string? LastError { get; private set; }
+
+        /// <summary>The retained tail of Velopack's own log, for failure reports.</summary>
+        public string UpdateLogTail() => _velopackLog.RecentLog();
 
         /// <summary>
         /// Starts the background update check loop. Call once at app startup.
@@ -163,10 +184,14 @@ namespace EveLens.Common.Services
         public async Task<bool> DownloadUpdateAsync(Action<int>? progress = null)
         {
             if (_pendingUpdate == null)
+            {
+                LastError = "No update has been found to download.";
                 return false;
+            }
 
             try
             {
+                LastError = null;
                 AppServices.TraceService?.Trace(
                     $"VelopackUpdate: Downloading {_pendingUpdate.TargetFullRelease?.Version}...");
 
@@ -177,7 +202,12 @@ namespace EveLens.Common.Services
             }
             catch (Exception ex)
             {
-                AppServices.TraceService?.Trace($"VelopackUpdate: Download failed: {ex.Message}");
+                // Redacted: exception messages and stack traces carry absolute paths
+                // (and thus the OS account name), and both this trace line and LastError
+                // end up in places users share — the trace log and the failure dialog.
+                LastError = ex.Message.RedactUserName();
+                AppServices.TraceService?.Trace(
+                    $"VelopackUpdate: Download failed: {ex.ToString().RedactUserName()}");
                 return false;
             }
         }
@@ -185,13 +215,37 @@ namespace EveLens.Common.Services
         /// <summary>
         /// Applies the downloaded update and restarts the app.
         /// </summary>
-        public void ApplyAndRestart()
+        /// <returns>
+        /// Never returns on success — Velopack hands off to the updater and exits the
+        /// process. A return of false therefore means the handoff itself failed, and
+        /// <see cref="LastError"/> says why.
+        /// </returns>
+        public bool ApplyAndRestart()
         {
             if (_pendingUpdate?.TargetFullRelease == null)
-                return;
+            {
+                LastError = "No downloaded update is ready to apply.";
+                return false;
+            }
 
-            AppServices.TraceService?.Trace("VelopackUpdate: Applying update and restarting...");
-            _manager.ApplyUpdatesAndRestart(_pendingUpdate.TargetFullRelease);
+            try
+            {
+                LastError = null;
+                AppServices.TraceService?.Trace("VelopackUpdate: Applying update and restarting...");
+                _manager.ApplyUpdatesAndRestart(_pendingUpdate.TargetFullRelease);
+                return true;
+            }
+            catch (Exception ex)
+            {
+                // Reaching here means the updater never took over: it could not be
+                // launched, or refused the package. Silence here is what left macOS
+                // users staring at an unchanged version number. LastProblem is already
+                // redacted by VelopackTraceLogger; the raw exception is not.
+                LastError = _velopackLog.LastProblem ?? ex.Message.RedactUserName();
+                AppServices.TraceService?.Trace(
+                    $"VelopackUpdate: Apply failed: {ex.ToString().RedactUserName()}");
+                return false;
+            }
         }
 
         /// <summary>

--- a/src/EveLens.Data/Extensions/StringExtensions.cs
+++ b/src/EveLens.Data/Extensions/StringExtensions.cs
@@ -23,6 +23,14 @@ namespace EveLens.Common.Extensions
             @"\d{1,3}\.){3}\d{1,3}\])|(([0-9a-zA-Z][-\w]*[0-9a-zA-Z]\.)+[a-zA-Z]{2,6}))$");
         private static readonly Regex s_removePath = new Regex(@"[a-zA-Z]+:\\.*\\(?=EveLens)",
             RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        // The username runs to the next backslash when the path continues (usernames
+        // may contain spaces there), otherwise to the next space/quote/line end.
+        private static readonly Regex s_windowsUserName = new Regex(
+            @"(?<=[a-zA-Z]:\\Users\\)(?:[^\\\r\n]*?(?=\\)|[^\\\s'""]+)",
+            RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        private static readonly Regex s_unixUserName = new Regex(
+            @"(?<=/(?:Users|home)/)[^/\s""']+",
+            RegexOptions.Compiled);
         private static readonly Regex s_unicode = new Regex(@"\\u(?<Value>[a-zA-Z0-9]{4})",
             RegexOptions.Compiled);
         private static readonly Regex s_upperText = new Regex("\\B([A-Z])",
@@ -35,6 +43,44 @@ namespace EveLens.Common.Extensions
         /// <returns></returns>
         public static string RemoveProjectLocalPath(this string text) => s_removePath.Replace(
             text, string.Empty);
+
+        /// <summary>
+        /// Redacts the OS account name from the text: the username segment of home
+        /// directory paths (<c>C:\Users\name\...</c>, <c>/Users/name/...</c>,
+        /// <c>/home/name/...</c>) and any bare occurrence of the current OS username.
+        /// </summary>
+        /// <remarks>
+        /// Third-party libraries (Velopack in particular) log absolute paths, and those
+        /// lines end up in the trace log — which users paste into GitHub issues — and on
+        /// the TCP diagnostic stream. The OS account name is PII; scrub it once at the
+        /// point the text enters our logging, so every downstream copy is already clean.
+        /// </remarks>
+        /// <param name="text">The text to redact.</param>
+        /// <returns>The text with usernames replaced by <c>[REDACTED]</c>.</returns>
+        public static string RedactUserName(this string text)
+        {
+            if (string.IsNullOrEmpty(text))
+                return text;
+
+            text = s_windowsUserName.Replace(text, "[REDACTED]");
+            text = s_unixUserName.Replace(text, "[REDACTED]");
+
+            try
+            {
+                // Belt and braces for messages that name the account outside a path
+                // (e.g. elevation prompts). Skip very short usernames — replacing a
+                // two-letter name would mangle ordinary words containing it.
+                string userName = Environment.UserName;
+                if (!string.IsNullOrEmpty(userName) && userName.Length >= 3)
+                    text = text.Replace(userName, "[REDACTED]");
+            }
+            catch
+            {
+                // Environment may throw in sandboxed contexts
+            }
+
+            return text;
+        }
 
         /// <summary>
         /// Converts a string that has been HTML-encoded for HTTP transmission into a decoded

--- a/tests/EveLens.Tests/Extensions/RedactUserNameTests.cs
+++ b/tests/EveLens.Tests/Extensions/RedactUserNameTests.cs
@@ -1,0 +1,97 @@
+// EveLens — Character Intelligence for EVE Online
+// Copyright © 2006-2021 EVEMon Development Team, © 2025-2026 Alia Collins
+// Built with Claude Code (Anthropic)
+// Licensed under GPL v2 — see LICENSE for details
+
+using System;
+using EveLens.Common.Extensions;
+using FluentAssertions;
+using Xunit;
+
+namespace EveLens.Tests.Extensions
+{
+    /// <summary>
+    /// Tests for <see cref="StringExtensions.RedactUserName"/>, the scrub applied to
+    /// every log line that enters EveLens from a third-party library.
+    /// </summary>
+    /// <remarks>
+    /// These exist because Velopack logs absolute paths — which embed the OS account
+    /// name — and those lines flow into the trace log (which users paste into GitHub
+    /// issues), the TCP diagnostic stream, and the update failure dialog. If any of
+    /// these assertions break, an OS username is being sent off the user's machine.
+    /// </remarks>
+    public class RedactUserNameTests
+    {
+        [Theory]
+        [InlineData(@"C:\Users\alia\AppData\Local\EveLens\packages\EveLens-1.5.0-full.nupkg",
+                    @"C:\Users\[REDACTED]\AppData\Local\EveLens\packages\EveLens-1.5.0-full.nupkg")]
+        [InlineData(@"D:\Users\alia\Downloads", @"D:\Users\[REDACTED]\Downloads")]
+        public void RedactsWindowsHomePaths(string input, string expected)
+        {
+            input.RedactUserName().Should().Be(expected);
+        }
+
+        [Fact]
+        public void RedactsWindowsPathEndingAtTheUsername()
+        {
+            // The DiagnosticReportBuilder regex requires a trailing backslash and
+            // misses this shape; the extension must not.
+            @"Access to 'C:\Users\alia' was denied".RedactUserName()
+                .Should().Be(@"Access to 'C:\Users\[REDACTED]' was denied");
+        }
+
+        [Theory]
+        [InlineData("/Users/alia/Library/Caches/velopack/EveLens/packages",
+                    "/Users/[REDACTED]/Library/Caches/velopack/EveLens/packages")]
+        [InlineData("Replacing bundle at /Users/alia/Downloads/EveLens.app",
+                    "Replacing bundle at /Users/[REDACTED]/Downloads/EveLens.app")]
+        [InlineData("/home/alia/.local/share/EveLens", "/home/[REDACTED]/.local/share/EveLens")]
+        public void RedactsUnixHomePaths(string input, string expected)
+        {
+            // macOS is where the in-place updater runs — this is the path shape
+            // that the old Windows-only redaction let straight through.
+            input.RedactUserName().Should().Be(expected);
+        }
+
+        [Fact]
+        public void RedactsPathsInsideQuotes()
+        {
+            "could not rename \"/Users/alia/Applications/EveLens.app\"".RedactUserName()
+                .Should().Be("could not rename \"/Users/[REDACTED]/Applications/EveLens.app\"");
+        }
+
+        [Fact]
+        public void RedactsTheCurrentOsUserNameOutsideAnyPath()
+        {
+            string userName = Environment.UserName;
+            // Short usernames are deliberately left alone (see next test) —
+            // nothing to assert against on such a machine.
+            if (userName.Length < 3)
+                return;
+
+            $"elevation requested for {userName}".RedactUserName()
+                .Should().NotContain(userName).And.Contain("[REDACTED]");
+        }
+
+        [Fact]
+        public void LeavesOrdinaryTextAlone()
+        {
+            const string text = "EveLens 1.5.0 downloaded update from " +
+                "https://github.com/aliacollins/evelens (200 OK)";
+            // The current OS username could legitimately occur inside ordinary
+            // words; only assert no damage when it does not.
+            if (text.Contains(Environment.UserName))
+                return;
+
+            text.RedactUserName().Should().Be(text);
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData(null)]
+        public void PassesThroughNullAndEmpty(string? input)
+        {
+            input!.RedactUserName().Should().Be(input);
+        }
+    }
+}

--- a/tests/EveLens.Tests/Services/VelopackTraceLoggerTests.cs
+++ b/tests/EveLens.Tests/Services/VelopackTraceLoggerTests.cs
@@ -1,0 +1,248 @@
+// EveLens — Character Intelligence for EVE Online
+// Copyright © 2006-2021 EVEMon Development Team, © 2025-2026 Alia Collins
+// Built with Claude Code (Anthropic)
+// Licensed under GPL v2 — see LICENSE for details
+
+using System;
+using System.Collections.Generic;
+using EveLens.Common.Services;
+using EveLens.Core.Interfaces;
+using FluentAssertions;
+using NSubstitute;
+using Velopack.Logging;
+using Xunit;
+
+namespace EveLens.Tests.Services
+{
+    /// <summary>
+    /// Tests for <see cref="VelopackTraceLogger"/>, the sink that carries Velopack's
+    /// account of an update into the EveLens trace log.
+    /// </summary>
+    /// <remarks>
+    /// These exist because a macOS in-place update could fail leaving no evidence
+    /// anywhere a user or maintainer could reach: Velopack had no logger installed, so
+    /// its reason for refusing an update was discarded, and the only symptom was a
+    /// version number that did not change. Every assertion here protects a piece of
+    /// that missing evidence trail.
+    /// </remarks>
+    [Collection("AppServices")]
+    public class VelopackTraceLoggerTests
+    {
+        public VelopackTraceLoggerTests() => AppServices.Reset();
+
+        /// <summary>Captures trace output so forwarding can be asserted.</summary>
+        private static (VelopackTraceLogger logger, List<string> traced) NewLogger()
+        {
+            var traced = new List<string>();
+            var trace = Substitute.For<ITraceService>();
+            trace.When(t => t.Trace(Arg.Any<string>(), Arg.Any<bool>()))
+                 .Do(ci => traced.Add(ci.ArgAt<string>(0)));
+            AppServices.SetTraceService(trace);
+            return (new VelopackTraceLogger(), traced);
+        }
+
+        [Fact]
+        public void ImplementsVelopackLoggerInterface()
+        {
+            // Velopack only accepts IVelopackLogger; if this breaks, the logger
+            // silently stops being installed and we lose the evidence trail again.
+            new VelopackTraceLogger().Should().BeAssignableTo<IVelopackLogger>();
+        }
+
+        [Fact]
+        public void ForwardsInformationToTraceService()
+        {
+            var (logger, traced) = NewLogger();
+
+            logger.Log(VelopackLogLevel.Information, "Applying package", null);
+
+            traced.Should().ContainSingle()
+                .Which.Should().Contain("Applying package").And.Contain("Velopack");
+        }
+
+        [Fact]
+        public void DropsChattyLevelsBelowInformation()
+        {
+            var (logger, traced) = NewLogger();
+
+            logger.Log(VelopackLogLevel.Trace, "chunk 1 of 900", null);
+            logger.Log(VelopackLogLevel.Debug, "chunk 2 of 900", null);
+
+            // Per-chunk download progress would drown the trace file for no gain.
+            traced.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void IgnoresEmptyMessageWithNoException()
+        {
+            var (logger, traced) = NewLogger();
+
+            logger.Log(VelopackLogLevel.Information, "   ", null);
+
+            traced.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void IncludesExceptionTypeAndMessage()
+        {
+            var (logger, traced) = NewLogger();
+
+            logger.Log(VelopackLogLevel.Error, "Failed to apply",
+                new UnauthorizedAccessException("bundle is read-only"));
+
+            traced.Should().ContainSingle().Which.Should()
+                .Contain("Failed to apply")
+                .And.Contain("UnauthorizedAccessException")
+                .And.Contain("bundle is read-only");
+        }
+
+        [Fact]
+        public void LastProblemStartsNull()
+        {
+            var (logger, _) = NewLogger();
+
+            logger.LastProblem.Should().BeNull();
+        }
+
+        [Fact]
+        public void InformationDoesNotCountAsAProblem()
+        {
+            var (logger, _) = NewLogger();
+
+            logger.Log(VelopackLogLevel.Information, "Downloading update", null);
+
+            // Only warnings and worse are shown to the user as a failure reason.
+            logger.LastProblem.Should().BeNull();
+        }
+
+        [Theory]
+        [InlineData(VelopackLogLevel.Warning)]
+        [InlineData(VelopackLogLevel.Error)]
+        [InlineData(VelopackLogLevel.Critical)]
+        public void CapturesWarningsAndWorseAsLastProblem(VelopackLogLevel level)
+        {
+            var (logger, _) = NewLogger();
+
+            logger.Log(level, "User cancelled elevation prompt", null);
+
+            // This is the string the update dialog shows instead of silently
+            // resetting the button and leaving the user on the old version.
+            logger.LastProblem.Should().Be("User cancelled elevation prompt");
+        }
+
+        [Fact]
+        public void LastProblemKeepsTheMostRecentFailure()
+        {
+            var (logger, _) = NewLogger();
+
+            logger.Log(VelopackLogLevel.Warning, "first failure", null);
+            logger.Log(VelopackLogLevel.Error, "second failure", null);
+
+            logger.LastProblem.Should().Be("second failure");
+        }
+
+        [Fact]
+        public void RecentLogKeepsOrderNewestLast()
+        {
+            var (logger, _) = NewLogger();
+
+            logger.Log(VelopackLogLevel.Information, "step one", null);
+            logger.Log(VelopackLogLevel.Information, "step two", null);
+
+            string tail = logger.RecentLog();
+            tail.IndexOf("step one", StringComparison.Ordinal).Should()
+                .BeLessThan(tail.IndexOf("step two", StringComparison.Ordinal));
+        }
+
+        [Fact]
+        public void RecentLogIsBoundedSoItCannotGrowForever()
+        {
+            var (logger, _) = NewLogger();
+
+            for (int i = 0; i < 100; i++)
+                logger.Log(VelopackLogLevel.Information, $"line {i}", null);
+
+            string[] lines = logger.RecentLog()
+                .Split(Environment.NewLine, StringSplitOptions.RemoveEmptyEntries);
+
+            lines.Should().HaveCount(20);
+            lines[^1].Should().Contain("line 99");
+            logger.RecentLog().Should().NotContain("line 0 ");
+        }
+
+        [Fact]
+        public void RedactsOsUserNameFromMacHomePathsBeforeTracing()
+        {
+            var (logger, traced) = NewLogger();
+
+            // The exact shape UpdateMac logs during an apply. The trace log is what
+            // users paste into GitHub issues, and it also leaves the machine on the
+            // TCP diagnostic stream — the account name must never reach either.
+            logger.Log(VelopackLogLevel.Information,
+                "Replacing bundle at /Users/alia/Applications/EveLens.app", null);
+
+            traced.Should().ContainSingle().Which.Should()
+                .NotContain("alia").And.Contain("/Users/[REDACTED]/Applications");
+        }
+
+        [Fact]
+        public void RedactsOsUserNameFromWindowsPathsBeforeTracing()
+        {
+            var (logger, traced) = NewLogger();
+
+            logger.Log(VelopackLogLevel.Information,
+                @"Reading packages from C:\Users\alia\AppData\Local\EveLens\packages", null);
+
+            traced.Should().ContainSingle().Which.Should()
+                .NotContain("alia").And.Contain(@"C:\Users\[REDACTED]\AppData");
+        }
+
+        [Fact]
+        public void LastProblemIsRedactedBecauseTheDialogShowsIt()
+        {
+            var (logger, _) = NewLogger();
+
+            // LastProblem becomes LastError becomes dialog text — and dialog text
+            // gets screenshotted and pasted into issues just like the trace log.
+            logger.Log(VelopackLogLevel.Error, "Failed to apply",
+                new UnauthorizedAccessException(
+                    "Access to the path '/Users/alia/Applications/EveLens.app' is denied."));
+
+            logger.LastProblem.Should()
+                .NotContain("alia").And.Contain("/Users/[REDACTED]/");
+        }
+
+        [Fact]
+        public void RecentLogTailIsRedacted()
+        {
+            var (logger, _) = NewLogger();
+
+            logger.Log(VelopackLogLevel.Information,
+                "Extracting to /home/alia/.local/share/velopack", null);
+
+            logger.RecentLog().Should()
+                .NotContain("alia").And.Contain("/home/[REDACTED]/");
+        }
+
+        [Fact]
+        public void LoggingNeverThrowsWhenTraceServiceIsAbsent()
+        {
+            // The startup hook installs this logger before any services exist —
+            // it must never be the reason the app fails to start.
+            AppServices.Reset();
+            var logger = new VelopackTraceLogger();
+
+            Action act = () => logger.Log(VelopackLogLevel.Error, "boom", new Exception("x"));
+
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public void AppServicesExposesASingleSharedInstance()
+        {
+            // The startup hook and VelopackUpdateService must see the same log,
+            // otherwise the service cannot report what the hook observed.
+            AppServices.VelopackLogger.Should().BeSameAs(AppServices.VelopackLogger);
+        }
+    }
+}

--- a/updates/evelens-patch-beta.xml
+++ b/updates/evelens-patch-beta.xml
@@ -7,6 +7,16 @@
   <releases>
     <release>
       <date>2026-08-28</date>
+      <version>1.5.0.18</version>
+      <url>https://github.com/aliacollins/evelens/releases/tag/beta</url>
+      <autopatchurl>https://github.com/aliacollins/evelens/releases/download/beta/EveLens-install-1.5.0.exe</autopatchurl>
+      <autopatchargs>/SILENT</autopatchargs>
+      <message><![CDATA[EveLens 1.5.0-beta.18
+
+Update diagnostics: Velopack log into trace (PII-redacted), failure dialog with real reason]]></message>
+    </release>
+    <release>
+      <date>2026-08-28</date>
       <version>1.5.0.17</version>
       <url>https://github.com/aliacollins/evelens/releases/tag/beta</url>
       <autopatchurl>https://github.com/aliacollins/evelens/releases/download/beta/EveLens-install-1.5.0.exe</autopatchurl>
@@ -94,16 +104,6 @@ SKINR landing + monitored SKINR data, priority feature, Doctrine clipboard/froze
       <message><![CDATA[EveLens 1.5.0-beta.9
 
 Plan editor order fix, priority submenu, Doctrine Designer improvements (#135 #136 #137)]]></message>
-    </release>
-    <release>
-      <date>2026-08-26</date>
-      <version>1.5.0.8</version>
-      <url>https://github.com/aliacollins/evelens/releases/tag/beta</url>
-      <autopatchurl>https://github.com/aliacollins/evelens/releases/download/beta/EveLens-install-1.5.0.exe</autopatchurl>
-      <autopatchargs>/SILENT</autopatchargs>
-      <message><![CDATA[EveLens 1.5.0-beta.8
-
-Beta 8: overview sort/reorder controls appear when the second character arrives]]></message>
     </release>
   </releases>
   <datafiles>


### PR DESCRIPTION
Automated promotion: experimental/skinr -> beta (1.5.0-beta.18)

Update diagnostics: Velopack log into trace (PII-redacted), failure dialog with real reason