### PR TITLE
1.5.1 docs: README, changelog cleanup, release asset curation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,18 +8,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [1.5.1] - 2026-08-28
-- **Carbon & Trinity, now in EveLens** -- CCP's open-sourced game engine renders everything in the new SKINR Studio: your designs in 3D, Photo Op fleet portraits, and the entire Paragon Hub marketplace as real renders
-- **macOS, first class** -- code-signed, notarized, and self-updating in place; no more Gatekeeper warnings, no more manual downloads
-- **.NET 10 and Avalonia 12** -- the whole app moved to the newest runtime and UI framework, on all three platforms
-- **Doctrine Designer, round two** -- a full fleet-readiness workbench, built with the community issue by issue
 
-- **macOS now ships a proper .dmg installer.** Drag EveLens to Applications the way every Mac app installs -- that Finder drag is also what tells macOS Gatekeeper the install is deliberate, which is essential for auto-updates to work (see the fix below). The .dmg is code-signed and notarized; the .app.zip remains available.
+### Added
+
+- **macOS now ships a proper .dmg installer.** Drag EveLens to Applications the way every Mac app installs -- that Finder drag is also what tells macOS Gatekeeper the install is deliberate, which is essential for auto-updates to work (see the fix below). The .dmg is code-signed and notarized, and it is now the one macOS download -- the loose .zip archives are retired, because unzip-and-move installs are exactly what broke auto-updates (see below).
 
 ### Fixed
 
 - **Solved: macOS updates that download but never install.** The root cause of the "version never changes" reports: when EveLens is placed in Applications without a Finder drag (Terminal move, unzip in place, or run straight from Downloads), macOS Gatekeeper silently runs a read-only mirror of the app -- App Translocation -- and the updater's final swap is refused every time, invisibly, after the app has already exited. EveLens now detects this state at startup and offers a one-click repair (moves itself properly into Applications, clears the quarantine flag, relaunches); the Download & Restart button also refuses honestly with an explanation instead of pretending to succeed. New installs avoid the trap entirely via the .dmg.
 
-- An update that fails to install now says so, and why, instead of quietly leaving you on the old version. Previously a failed download or a refused install just reset the Download & Restart button, so an update that never happened looked exactly like one that did -- the report you would have had to send us contained no more information than "the version didn't change". Velopack's own account of the update now goes into the EveLens trace log alongside everything else, which matters most on macOS, where the app replaces itself in place and the only visible evidence was the version number. Because these updater messages contain file paths and a per-install identifier, the OS account name and any GUIDs are scrubbed from them before they reach the trace log or the error dialog -- nothing personal ends up in what you share with us.
+- An update that fails to install now says so, and why, instead of quietly leaving you on the old version. The updater's own log joins EveLens's local diagnostics on your machine (EveLens never sends anything anywhere), with usernames and identifiers scrubbed out just in case you ever choose to attach it to a bug report.
+
 ## [1.5.0] - 2026-08-28
 
 **The SKINR update -- the biggest release in EveLens history**, packed with new features, engineering overhauls, and community-driven fixes. The headline: EveLens now renders your actual SKIN designs on your actual ships, in real 3D, using **CCP's own Carbon Engine and Trinity graphics engine** -- the same renderer EVE Online itself uses, which CCP open-sourced under MIT. A game engine, running inside a character tool. Around it, the four biggest changes EveLens has ever shipped at once:

--- a/README.md
+++ b/README.md
@@ -23,16 +23,15 @@ It runs natively on **Windows, Linux, and macOS** (signed and notarized), built 
 
 **[Download EveLens](https://github.com/aliacollins/evelens/releases/latest)**
 
-| Platform | Format | Requirements |
-|----------|--------|-------------|
-| **Windows (Installer)** | `EveLens-stable-Setup.exe` | None -- .NET runtime is bundled |
-| **Windows (Portable)** | `EveLens-stable-Portable.zip` | None -- .NET runtime is bundled |
-| **Linux (AppImage)** | `EveLens-*-linux-x86_64.AppImage` | None -- single file, just run |
-| **Linux (Portable)** | `EveLens-*-linux-x64.zip` | None -- .NET runtime is bundled |
-| **macOS (App)** | `EveLens-*-osx-arm64.app.zip` | None -- extract and run |
-| **macOS (Portable)** | `EveLens-*-osx-arm64.zip` | None -- .NET runtime is bundled |
+One download per platform -- everything is self-contained, no .NET runtime install needed:
 
-The Windows installer is **code-signed** by a verified Certum certificate.
+| Platform | Format |
+|----------|--------|
+| **Windows** | `EveLens-stable-Setup.exe` -- installer with shortcuts and auto-updates |
+| **macOS (Apple Silicon)** | `EveLens-*-osx-arm64.dmg` -- drag to Applications |
+| **Linux** | `EveLens-*-linux-x86_64.AppImage` -- single file, just run |
+
+The Windows installer is **code-signed** by a verified Certum certificate; the macOS app and disk image are **signed and notarized by Apple**.
 
 ---
 
@@ -42,7 +41,7 @@ The Windows installer is **code-signed** by a verified Certum certificate.
 
 Download and run `EveLens-stable-Setup.exe`. The installer handles everything -- .NET runtime, shortcuts, auto-updates. The binary is code-signed, so Windows SmartScreen won't block it.
 
-### Linux (AppImage -- Recommended)
+### Linux (AppImage)
 
 ```bash
 # Download the AppImage from the release page, then:
@@ -52,24 +51,15 @@ chmod +x EveLens-*-linux-x86_64.AppImage
 
 That's it. Single file, no install, no dependencies. Works on Ubuntu, Fedora, Arch, and most distros.
 
-### Linux (Portable)
-
-```bash
-unzip EveLens-*-linux-x64.zip -d evelens
-chmod +x evelens/EveLens
-./evelens/EveLens
-```
-
-No separate .NET runtime install needed -- releases are self-contained.
-
 ### macOS (Apple Silicon)
 
-1. Download `EveLens-*-osx-arm64.app.zip` from the release page
-2. Extract the zip -- you'll get `EveLens.app`
-3. Drag `EveLens.app` to your Applications folder (or run it from anywhere -- it's portable)
-4. Double-click to open. That's it.
+1. Download `EveLens-*-osx-arm64.dmg` from the release page
+2. Open it and drag **EveLens** onto the **Applications** shortcut
+3. Launch EveLens from Applications. That's it.
 
-**EveLens is code-signed and notarized by Apple** as of 1.5.0 -- Gatekeeper opens it like any Mac app. No Terminal, no `xattr`, no right-click workarounds. And the app **updates itself in place** from here on: Check for Updates downloads the new version, swaps the .app wherever you keep it, and relaunches.
+**EveLens is code-signed and notarized by Apple** -- Gatekeeper opens it like any Mac app. No Terminal, no `xattr`, no right-click workarounds. And the app **updates itself in place**: Check for Updates downloads the new version, swaps the .app, and relaunches.
+
+The drag-to-Applications step matters more than it looks: it is how macOS knows you installed the app on purpose, which is what allows self-updating to work. (Installing by Terminal or unzip used to break updates silently -- 1.5.1 detects and repairs that state automatically.)
 
 > **Coming from EVEMon?** We recommend a fresh start. EveLens is a complete rewrite -- your EVE characters are tied to your ESI tokens, not your old settings. Add your characters through the ESI login and you're good to go.
 
@@ -177,7 +167,15 @@ I'm not accepting donations -- I just want to know if EveLens makes your EVE lif
 
 ---
 
-## What's New in 1.5.0
+## What's New in 1.5.1
+
+- **macOS .dmg installer** -- drag to Applications like every Mac app; signed and notarized. Now the one macOS download.
+- **Solved: mac updates that downloaded but never installed** -- apps placed in Applications without a Finder drag were silently running from a read-only Gatekeeper copy (App Translocation) where updates can never apply. EveLens now detects this at startup and repairs it with one click.
+- **Updates fail loudly now** -- a failed download or install says so, with the reason, instead of quietly leaving you on the old version.
+
+Full details: [CHANGELOG.md](CHANGELOG.md)
+
+## What Was New in 1.5.0
 
 - **The SKINR Studio** -- your SKIN designs on your ships, rendered in real 3D by EVE's own engine; five environments, Photo Op fleet shots, one-time 3D engine download (community preview images without it)
 - **Paragon Hub browser** -- every marketplace design as a real render, side by side, with instant pre-resolved identities and preview images
@@ -186,20 +184,6 @@ I'm not accepting donations -- I just want to know if EveLens makes your EVE lif
 - **Overview rework** -- drag-to-group, sort and density controls, group totals, saved comparisons
 - **macOS first class** -- signed, notarized, and self-updating in place; Linux gets update checks too
 - **.NET 10** and EVE static data build 3480926
-
-Full details: [CHANGELOG.md](CHANGELOG.md)
-
-## What Was New in 1.4.0
-
-- **Doctrine Designer** -- create shared skill templates, assign characters, compare training times, generate personal plans (Ctrl+G)
-- **Chinese language (简体中文)** -- full UI + 50K SDE translations with CCP official game terms
-- **CSV export** -- export skills and queue from the Skills and Queue tabs
-- **Skill Farm sort** -- click column headers to sort, "Add All Eligible" for batch adding
-- **Plan editor overhaul** -- whole-row drag (no grip dots), scroll offset fix, attribute group headers, specific prereq error messages
-- **macOS fixes** -- Cmd+W closes plan windows, menu title fixed, Unicode font fallback
-- **Windows icon fix** -- taskbar icon no longer reverts to default
-- **Attribute optimizer** -- "Reset to Current" and manual adjustments now produce correct results
-- **Website download links** -- no longer 404 between releases
 
 Full details: [CHANGELOG.md](CHANGELOG.md)
 
@@ -223,6 +207,7 @@ Full details: [CHANGELOG.md](CHANGELOG.md)
 
 | Version | Date | Highlights |
 |---------|------|------------|
+| **[1.5.1](https://github.com/aliacollins/EveLens/releases/tag/v1.5.1)** | August 28, 2026 | macOS .dmg installer, App Translocation self-heal (fixes silently-failing mac updates), loud update failures with PII-scrubbed updater log |
 | **[1.5.0](https://github.com/aliacollins/EveLens/releases/tag/v1.5.0)** | August 28, 2026 | The SKINR Studio (CCP's Carbon/Trinity engine in EveLens), Paragon Hub browser, Photo Op, macOS signed + self-updating, .NET 10 + Avalonia 12, Doctrine Designer round two, Plan Editor rebuild |
 | **[1.4.1](https://github.com/aliacollins/EveLens/releases/tag/v1.4.1)** | August 10, 2026 | Korean language, PI overhaul, community fix train, SDE 3458726 |
 | **[1.3.0](https://github.com/aliacollins/EveLens/releases/tag/v1.3.0)** | May 10, 2026 | Doctrine Designer, Chinese language, CSV export, Skill Farm sort, plan editor overhaul |

--- a/scripts/release.ps1
+++ b/scripts/release.ps1
@@ -218,16 +218,12 @@ try {
         Write-Warning "AppImage creation failed -- zip will be uploaded instead."
     }
 
-    # ── macOS: .app bundle + raw zip ──
+    # ── macOS: .app bundle → DMG ──
+    # One human-facing mac download: the DMG. The raw osx zip and .app.zip used
+    # to ship alongside it, which meant three mac files on every release page —
+    # and the zips invite exactly the Terminal-install habits that cause
+    # Gatekeeper App Translocation. Velopack machinery (nupkg + feed) still rides.
     Write-Host "`n=== Creating macOS .app bundle ===" -ForegroundColor Cyan
-    $macZip = $OtherPlatforms[1].Zip
-    if (Test-Path $macZip) { Remove-Item $macZip -Force }
-    Compress-Archive -Path "$($OtherPlatforms[1].Dir)/*" -DestinationPath $macZip
-    Write-Host "  Zipped osx-arm64." -ForegroundColor Green
-
-    # Build .app bundle via WSL to preserve Unix permissions and executable bit
-    $appBundleZip = "releases/EveLens-${Channel}-osx-arm64.app.zip"
-    if (Test-Path $appBundleZip) { Remove-Item $appBundleZip -Force }
 
     # make-macapp.sh is a real source file taking (channel, version) as arguments.
     # It used to be GENERATED here with the version baked in, which dirtied the
@@ -256,8 +252,6 @@ try {
                 -AppBundle $appBundle
             if ($LASTEXITCODE -ne 0) { throw "macOS signing/notarization failed." }
         }
-        py -3.12 (Join-Path $PSScriptRoot 'release/zip-macapp.py') $appBundle $appBundleZip 'EveLens.app'
-        if ($LASTEXITCODE -ne 0) { throw "zip-macapp failed." }
         # The Velopack feed: full nupkg (carrying the SIGNED app) + the
         # releases.{channel}-osx.json the in-app GithubSource reads. Both must
         # ride the same GitHub release as each other.
@@ -289,7 +283,7 @@ try {
             Write-Warning "DMG creation failed -- release continues without it (zip still ships)."
         }
     } else {
-        Write-Warning "macOS .app bundle creation failed -- raw zip will be uploaded instead."
+        Write-Warning "macOS .app bundle creation failed -- this release ships without macOS artifacts."
     }
 }
 finally {
@@ -302,44 +296,31 @@ finally {
 Write-Host "`n=== Artifacts ===" -ForegroundColor Cyan
 $allFiles = @()
 
-# Windows (Velopack, signed)
-Get-ChildItem $WinPlatform.Out | ForEach-Object {
+# Windows (Velopack, signed). Portable.zip is a vpk byproduct we don't ship:
+# one human download per platform (Setup.exe), no parallel archive flavors.
+Get-ChildItem $WinPlatform.Out |
+    Where-Object { $_.Name -notlike '*-Portable.zip' } | ForEach-Object {
     $sizeMB = [math]::Round($_.Length / 1MB, 1)
     Write-Host "  $($_.Name) ($sizeMB MB) (signed)" -ForegroundColor Green
     $allFiles += $_.FullName
 }
 
-# Linux zip
-$file = Get-Item $OtherPlatforms[0].Zip
-$sizeMB = [math]::Round($file.Length / 1MB, 1)
-Write-Host "  $($file.Name) ($sizeMB MB)" -ForegroundColor Green
-$allFiles += $file.FullName
-
-# Linux AppImage (if created)
+# Linux AppImage (the one Linux download; the raw zip ships only as a
+# fallback when AppImage creation failed, so Linux is never left with nothing)
 $appImageFile = "releases/EveLens-${Channel}-linux-x86_64.AppImage"
 if (Test-Path $appImageFile) {
     $file = Get-Item $appImageFile
     $sizeMB = [math]::Round($file.Length / 1MB, 1)
     Write-Host "  $($file.Name) ($sizeMB MB)" -ForegroundColor Green
     $allFiles += $file.FullName
-}
-
-# macOS zip
-$file = Get-Item $OtherPlatforms[1].Zip
-$sizeMB = [math]::Round($file.Length / 1MB, 1)
-Write-Host "  $($file.Name) ($sizeMB MB)" -ForegroundColor Green
-$allFiles += $file.FullName
-
-# macOS .app bundle
-$appBundleZip = "releases/EveLens-${Channel}-osx-arm64.app.zip"
-if (Test-Path $appBundleZip) {
-    $file = Get-Item $appBundleZip
+} elseif (Test-Path $OtherPlatforms[0].Zip) {
+    $file = Get-Item $OtherPlatforms[0].Zip
     $sizeMB = [math]::Round($file.Length / 1MB, 1)
-    Write-Host "  $($file.Name) ($sizeMB MB)" -ForegroundColor Green
+    Write-Host "  $($file.Name) ($sizeMB MB) (AppImage fallback)" -ForegroundColor Yellow
     $allFiles += $file.FullName
 }
 
-# macOS .dmg installer (the recommended download — Finder drag-install
+# macOS .dmg installer (the one macOS download — Finder drag-install
 # prevents Gatekeeper App Translocation)
 $dmgArtifact = "releases/EveLens-${Channel}-osx-arm64.dmg"
 if (Test-Path $dmgArtifact) {


### PR DESCRIPTION
Docs and release-script follow-up for v1.5.1 (already shipped):

- README: DMG-based mac install guide, one download per platform, What's New in 1.5.1
- CHANGELOG: 1.5.1 section deduplicated and the updater-log entry reworded (old text implied data leaves the machine; nothing ever does)
- release.ps1: curated artifact list (Setup.exe / .dmg / .AppImage + Velopack machinery)

🤖 Generated with [Claude Code](https://claude.com/claude-code)